### PR TITLE
fix(devspace): remove probes from dev container to break sync deadlock

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -60,17 +60,20 @@ functions:
                 - sh
                 - -c
                 - |
-                  set -eu
+                  set -eux
                   elapsed=0
                   while [ ! -f /opt/app/data/go.mod ]; do
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 300 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
+                  echo "Files synced, starting buf generate..."
+                  ls -la /opt/app/data/
                   buf generate buf.build/agynio/api \
                     --include-imports \
                     --path agynio/api/runners/v1 \
                     --path agynio/api/identity/v1 \
                     --path agynio/api/authorization/v1
+                  echo "buf generate complete, starting go run..."
                   exec go run ./cmd/runners
               volumeMounts:
                 - name: data
@@ -115,6 +118,10 @@ functions:
         kubectl get pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
         echo "Diagnostic logs (tail 200):" >&2
         kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 >&2 || true
+        echo "Diagnostic previous logs (tail 200):" >&2
+        kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 --previous >&2 || true
+        echo "Diagnostic pod describe:" >&2
+        kubectl describe pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" >&2 || true
         exit 1
       fi
       echo "  still waiting... (${ELAPSED}s)"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -64,7 +64,7 @@ functions:
                   elapsed=0
                   while [ ! -f /opt/app/data/go.mod ]; do
                     sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                    [ "$elapsed" -ge 300 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
                   buf generate buf.build/agynio/api \
                     --include-imports \
@@ -75,26 +75,9 @@ functions:
               volumeMounts:
                 - name: data
                   mountPath: /opt/app/data
-              livenessProbe:
-                tcpSocket:
-                  port: 50051
-                initialDelaySeconds: 120
-                periodSeconds: 10
-                timeoutSeconds: 1
-                failureThreshold: 6
-              readinessProbe:
-                tcpSocket:
-                  port: 50051
-                initialDelaySeconds: 120
-                periodSeconds: 10
-                timeoutSeconds: 1
-                failureThreshold: 3
-              startupProbe:
-                tcpSocket:
-                  port: 50051
-                initialDelaySeconds: 10
-                periodSeconds: 5
-                failureThreshold: 60
+              livenessProbe: null
+              readinessProbe: null
+              startupProbe: null
               resources:
                 requests:
                   cpu: 500m


### PR DESCRIPTION
## Problem

The E2E `deploy` pipeline fails with a circular dependency deadlock between DevSpace file sync and Kubernetes pod readiness:

```
DevSpace waits for pod "Ready"
  → Readiness probe must pass
    → Port 50051 must be open
      → Go app must be running
        → Source must be compiled
          → Files must be synced
            → DevSpace must start sync
              → DevSpace waits for pod "Ready" ← DEADLOCK
```

### Evidence from PR #5 E2E run ([23646679113](https://github.com/agynio/runners/actions/runs/23646679113))

| Timestamp | Event |
|-----------|-------|
| 12:50:16 | Deployment patched, `start_dev` begins "Waiting for pod to become ready..." |
| 12:50:26 | Pod status: ContainerCreating |
| 12:50:47 | Startup probe fails (container Running, but DevSpace never proceeds) |
| 12:54:38 | CrashLoopBackOff (120s `go.mod` wait timeout expired — no files synced) |
| 13:00:16 | `start_dev` times out (5 min default): "couldn't find a pod / container in time" |

DevSpace **never** shows "Selected pod" or "sync Starting sync..." — it never established sync.

### Why agents-orchestrator works

Its chart has all probes disabled (`livenessProbe.enabled: false`, etc.). The pod becomes Ready immediately on Running → DevSpace connects, syncs files, `go.mod` appears well before timeout.

### Why runners fails

The Helm chart has `livenessProbe` and `readinessProbe` enabled (tcpSocket :50051). PR #5 added probes to the strategic merge patch, but they're still tcpSocket-based — readiness still requires port 50051 open before DevSpace will inject its sync helper.

## Solution

**Remove all probes from the patched dev container** using `null` values in the strategic merge patch:

```yaml
livenessProbe: null
readinessProbe: null
startupProbe: null
```

Per the [Kubernetes strategic merge patch spec](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md), setting a map field to `null` deletes it from the resource. This completely removes the probes from the container, making the pod Ready as soon as the container enters Running state.

### Expected flow after fix

1. `kubectl patch` applies strategic merge with `null` probes → new pod starts
2. Container enters Running → **immediately Ready** (no probes to gate readiness)
3. DevSpace `start_dev` detects Ready pod → injects sync helper → uploads source files (~3s based on agents-orchestrator timings)
4. `go.mod` appears → wait loop exits → `buf generate` → `go run` → port 50051 opens
5. `wait_for_runners` polls logs → sees "runners: ready" → pipeline succeeds

### Additional safety margin

Raised the `go.mod` wait timeout from 120s → 300s in case sync is slow in degraded environments.

## Changes

- `devspace.yaml`: Replace tcpSocket probe definitions with `null` in `patch_deployment` function
- `devspace.yaml`: Increase `go.mod` wait timeout from 120s to 300s

## Verification

This PR should be verified by the E2E workflow. Key indicators of success:
- DevSpace logs show "Selected pod" shortly after patch
- "sync Starting sync..." and "Initial sync completed" appear
- No CrashLoopBackOff
- "runners: ready" log appears
- Pipeline completes successfully