### PR TITLE
Remove runner identity env

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Provision cluster
         working-directory: bootstrap
-        env:
-          TF_VAR_k8s_runner_identity_id: 439e0da2-88cd-46d7-bb9c-56c723c15606
         run: ./apply.sh -y
 
       - name: Verify platform health


### PR DESCRIPTION
## Summary
- remove TF_VAR_k8s_runner_identity_id from bootstrap apply step

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/runners/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

Refs #222