### PR TITLE
feat(server): support runner labels

### DIFF
--- a/internal/server/runners.go
+++ b/internal/server/runners.go
@@ -51,7 +51,7 @@ type runnerInsertInput struct {
 type runnerUpdateInput struct {
 	ID     uuid.UUID
 	Name   *string
-	Labels map[string]string
+	Labels *map[string]string
 }
 
 func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunnerRequest) (*runnersv1.RegisterRunnerResponse, error) {
@@ -144,9 +144,10 @@ func (s *Server) UpdateRunner(ctx context.Context, req *runnersv1.UpdateRunnerRe
 		name = &trimmed
 	}
 
-	labels := req.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
+	var labels *map[string]string
+	if req.Labels != nil {
+		value := req.Labels
+		labels = &value
 	}
 
 	runner, err := s.updateRunner(ctx, runnerUpdateInput{ID: id, Name: name, Labels: labels})
@@ -286,11 +287,7 @@ func runnerAuthorizationTuple(runnerID uuid.UUID, organizationID *uuid.UUID) *au
 }
 
 func (s *Server) insertRunner(ctx context.Context, input runnerInsertInput) (runnerRecord, error) {
-	labels := input.Labels
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	labelsJSON, err := json.Marshal(labels)
+	labelsJSON, err := json.Marshal(input.Labels)
 	if err != nil {
 		return runnerRecord{}, err
 	}
@@ -380,13 +377,13 @@ func (s *Server) deleteRunner(ctx context.Context, id uuid.UUID) error {
 }
 
 func (s *Server) updateRunner(ctx context.Context, input runnerUpdateInput) (runnerRecord, error) {
-	labels := input.Labels
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	labelsJSON, err := json.Marshal(labels)
-	if err != nil {
-		return runnerRecord{}, err
+	labelsValue := pgtype.Text{Valid: false}
+	if input.Labels != nil {
+		labelsJSON, err := json.Marshal(*input.Labels)
+		if err != nil {
+			return runnerRecord{}, err
+		}
+		labelsValue = pgtype.Text{String: string(labelsJSON), Valid: true}
 	}
 
 	nameValue := pgtype.Text{Valid: false}
@@ -395,9 +392,9 @@ func (s *Server) updateRunner(ctx context.Context, input runnerUpdateInput) (run
 	}
 
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = $2, updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns),
+		fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns),
 		nameValue,
-		labelsJSON,
+		labelsValue,
 		input.ID,
 	)
 	runner, err := scanRunner(row)

--- a/internal/server/runners.go
+++ b/internal/server/runners.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,7 +26,7 @@ const (
 
 	zitiRunnerRoleAttribute = "runners"
 
-	runnerColumns = `id, name, organization_id, identity_id, status, created_at, updated_at`
+	runnerColumns = `id, name, organization_id, identity_id, status, labels, created_at, updated_at`
 )
 
 type runnerRecord struct {
@@ -34,6 +35,7 @@ type runnerRecord struct {
 	OrganizationID *uuid.UUID
 	IdentityID     uuid.UUID
 	Status         string
+	Labels         map[string]string
 }
 
 type runnerInsertInput struct {
@@ -43,12 +45,23 @@ type runnerInsertInput struct {
 	IdentityID       uuid.UUID
 	ServiceTokenHash string
 	Status           string
+	Labels           map[string]string
+}
+
+type runnerUpdateInput struct {
+	ID     uuid.UUID
+	Name   *string
+	Labels map[string]string
 }
 
 func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunnerRequest) (*runnersv1.RegisterRunnerResponse, error) {
 	name := strings.TrimSpace(req.GetName())
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "name must be provided")
+	}
+	labels := req.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
 	}
 
 	var organizationID *uuid.UUID
@@ -86,6 +99,7 @@ func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunn
 		IdentityID:       runnerID,
 		ServiceTokenHash: tokenHash,
 		Status:           runnerStatusPending,
+		Labels:           labels,
 	})
 	if err != nil {
 		s.cleanupRunnerAuthorization(ctx, runnerID, organizationID)
@@ -113,6 +127,37 @@ func (s *Server) GetRunner(ctx context.Context, req *runnersv1.GetRunnerRequest)
 		return nil, status.Errorf(codes.Internal, "convert runner: %v", err)
 	}
 	return &runnersv1.GetRunnerResponse{Runner: protoRunner}, nil
+}
+
+func (s *Server) UpdateRunner(ctx context.Context, req *runnersv1.UpdateRunnerRequest) (*runnersv1.UpdateRunnerResponse, error) {
+	id, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+
+	var name *string
+	if req.Name != nil {
+		trimmed := strings.TrimSpace(req.GetName())
+		if trimmed == "" {
+			return nil, status.Error(codes.InvalidArgument, "name must be provided")
+		}
+		name = &trimmed
+	}
+
+	labels := req.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	runner, err := s.updateRunner(ctx, runnerUpdateInput{ID: id, Name: name, Labels: labels})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	protoRunner, err := toProtoRunner(runner)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "convert runner: %v", err)
+	}
+	return &runnersv1.UpdateRunnerResponse{Runner: protoRunner}, nil
 }
 
 func (s *Server) ListRunners(ctx context.Context, req *runnersv1.ListRunnersRequest) (*runnersv1.ListRunnersResponse, error) {
@@ -241,16 +286,25 @@ func runnerAuthorizationTuple(runnerID uuid.UUID, organizationID *uuid.UUID) *au
 }
 
 func (s *Server) insertRunner(ctx context.Context, input runnerInsertInput) (runnerRecord, error) {
+	labels := input.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		return runnerRecord{}, err
+	}
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO runners (id, name, organization_id, identity_id, service_token_hash, status)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        RETURNING %s`, runnerColumns),
+		fmt.Sprintf(`INSERT INTO runners (id, name, organization_id, identity_id, service_token_hash, status, labels)
+	    VALUES ($1, $2, $3, $4, $5, $6, $7)
+	    RETURNING %s`, runnerColumns),
 		input.ID,
 		input.Name,
 		pgtype.UUID{Bytes: input.OrganizationIDBytes(), Valid: input.OrganizationID != nil},
 		input.IdentityID,
 		input.ServiceTokenHash,
 		input.Status,
+		labelsJSON,
 	)
 	runner, err := scanRunner(row)
 	if err != nil {
@@ -325,6 +379,37 @@ func (s *Server) deleteRunner(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+func (s *Server) updateRunner(ctx context.Context, input runnerUpdateInput) (runnerRecord, error) {
+	labels := input.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		return runnerRecord{}, err
+	}
+
+	nameValue := pgtype.Text{Valid: false}
+	if input.Name != nil {
+		nameValue = pgtype.Text{String: *input.Name, Valid: true}
+	}
+
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = $2, updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns),
+		nameValue,
+		labelsJSON,
+		input.ID,
+	)
+	runner, err := scanRunner(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return runnerRecord{}, NotFound("runner")
+		}
+		return runnerRecord{}, err
+	}
+	return runner, nil
+}
+
 func (s *Server) updateRunnerStatus(ctx context.Context, id uuid.UUID, statusValue string) error {
 	result, err := s.pool.Exec(ctx, `UPDATE runners SET status = $1, updated_at = NOW() WHERE id = $2`, statusValue, id)
 	if err != nil {
@@ -338,8 +423,9 @@ func (s *Server) updateRunnerStatus(ctx context.Context, id uuid.UUID, statusVal
 
 func scanRunner(row pgx.Row) (runnerRecord, error) {
 	var (
-		runner runnerRecord
-		orgID  pgtype.UUID
+		runner     runnerRecord
+		orgID      pgtype.UUID
+		labelsData []byte
 	)
 	if err := row.Scan(
 		&runner.Meta.ID,
@@ -347,10 +433,17 @@ func scanRunner(row pgx.Row) (runnerRecord, error) {
 		&orgID,
 		&runner.IdentityID,
 		&runner.Status,
+		&labelsData,
 		&runner.Meta.CreatedAt,
 		&runner.Meta.UpdatedAt,
 	); err != nil {
 		return runnerRecord{}, err
+	}
+	if err := json.Unmarshal(labelsData, &runner.Labels); err != nil {
+		return runnerRecord{}, err
+	}
+	if runner.Labels == nil {
+		runner.Labels = map[string]string{}
 	}
 	if orgID.Valid {
 		value := uuid.UUID(orgID.Bytes)
@@ -369,6 +462,7 @@ func toProtoRunner(record runnerRecord) (*runnersv1.Runner, error) {
 		Name:       record.Name,
 		IdentityId: record.IdentityID.String(),
 		Status:     status,
+		Labels:     record.Labels,
 	}
 	if record.OrganizationID != nil {
 		value := record.OrganizationID.String()

--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -2,12 +2,16 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"testing"
 	"time"
 
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/runners/.gen/go/agynio/api/identity/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	zitimanagementv1 "github.com/agynio/runners/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/google/uuid"
@@ -66,6 +70,178 @@ func (f fakeZitiManagementClient) ExtendIdentityLease(ctx context.Context, req *
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+type fakeIdentityClient struct {
+	registerIdentity func(ctx context.Context, req *identityv1.RegisterIdentityRequest) (*identityv1.RegisterIdentityResponse, error)
+}
+
+func (f fakeIdentityClient) RegisterIdentity(ctx context.Context, req *identityv1.RegisterIdentityRequest, opts ...grpc.CallOption) (*identityv1.RegisterIdentityResponse, error) {
+	if f.registerIdentity == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.registerIdentity(ctx, req)
+}
+
+func (f fakeIdentityClient) GetIdentityType(ctx context.Context, req *identityv1.GetIdentityTypeRequest, opts ...grpc.CallOption) (*identityv1.GetIdentityTypeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeIdentityClient) BatchGetIdentityTypes(ctx context.Context, req *identityv1.BatchGetIdentityTypesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetIdentityTypesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+type fakeAuthorizationClient struct {
+	write func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error)
+}
+
+func (f fakeAuthorizationClient) Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) BatchCheck(ctx context.Context, req *authorizationv1.BatchCheckRequest, opts ...grpc.CallOption) (*authorizationv1.BatchCheckResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) Write(ctx context.Context, req *authorizationv1.WriteRequest, opts ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	if f.write == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.write(ctx, req)
+}
+
+func (f fakeAuthorizationClient) Read(ctx context.Context, req *authorizationv1.ReadRequest, opts ...grpc.CallOption) (*authorizationv1.ReadResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) ListObjects(ctx context.Context, req *authorizationv1.ListObjectsRequest, opts ...grpc.CallOption) (*authorizationv1.ListObjectsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) ListUsers(ctx context.Context, req *authorizationv1.ListUsersRequest, opts ...grpc.CallOption) (*authorizationv1.ListUsersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func TestRegisterRunnerPersistsLabels(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	labels := map[string]string{"type": "gpu", "region": "us-east-1"}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatalf("failed to marshal labels: %v", err)
+	}
+
+	runnerID := uuid.New()
+	identityID := uuid.New()
+	now := time.Now().UTC()
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "labels", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, runnerStatusPending, labelsJSON, now, now)
+
+	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO runners (id, name, organization_id, identity_id, service_token_hash, status, labels)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7)\n\t    RETURNING %s", runnerColumns))
+	mockPool.ExpectQuery(matcher).
+		WithArgs(pgxmock.AnyArg(), "runner-1", pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), runnerStatusPending, labelsJSON).
+		WillReturnRows(rows)
+
+	var gotIdentityReq *identityv1.RegisterIdentityRequest
+	identityClient := fakeIdentityClient{
+		registerIdentity: func(ctx context.Context, req *identityv1.RegisterIdentityRequest) (*identityv1.RegisterIdentityResponse, error) {
+			gotIdentityReq = req
+			return &identityv1.RegisterIdentityResponse{}, nil
+		},
+	}
+	var gotWriteReq *authorizationv1.WriteRequest
+	authorizationClient := fakeAuthorizationClient{
+		write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+			gotWriteReq = req
+			return &authorizationv1.WriteResponse{}, nil
+		},
+	}
+
+	srv := New(Options{
+		Pool:                mockPool,
+		IdentityClient:      identityClient,
+		AuthorizationClient: authorizationClient,
+	})
+
+	resp, err := srv.RegisterRunner(context.Background(), &runnersv1.RegisterRunnerRequest{
+		Name:   "runner-1",
+		Labels: labels,
+	})
+	if err != nil {
+		t.Fatalf("RegisterRunner failed: %v", err)
+	}
+	if resp.GetRunner() == nil {
+		t.Fatal("expected runner in response")
+	}
+	if resp.GetRunner().GetName() != "runner-1" {
+		t.Fatalf("expected runner name %q, got %q", "runner-1", resp.GetRunner().GetName())
+	}
+	if !reflect.DeepEqual(resp.GetRunner().GetLabels(), labels) {
+		t.Fatalf("expected labels %v, got %v", labels, resp.GetRunner().GetLabels())
+	}
+	if resp.GetServiceToken() == "" {
+		t.Fatal("expected service token")
+	}
+	if gotIdentityReq == nil {
+		t.Fatal("expected RegisterIdentity to be called")
+	}
+	if gotWriteReq == nil {
+		t.Fatal("expected authorization Write to be called")
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestUpdateRunnerUpdatesLabels(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	runnerID := uuid.New()
+	identityID := uuid.New()
+	labels := map[string]string{"env": "prod", "type": "cpu"}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatalf("failed to marshal labels: %v", err)
+	}
+	now := time.Now().UTC()
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "labels", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-updated", pgtype.UUID{Valid: false}, identityID, runnerStatusOffline, labelsJSON, now, now)
+
+	matcher := regexp.QuoteMeta(fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = $2, updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns))
+	mockPool.ExpectQuery(matcher).
+		WithArgs(pgtype.Text{String: "runner-updated", Valid: true}, labelsJSON, runnerID).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	name := "runner-updated"
+	resp, err := srv.UpdateRunner(context.Background(), &runnersv1.UpdateRunnerRequest{
+		Id:     runnerID.String(),
+		Name:   &name,
+		Labels: labels,
+	})
+	if err != nil {
+		t.Fatalf("UpdateRunner failed: %v", err)
+	}
+	if resp.GetRunner() == nil {
+		t.Fatal("expected runner in response")
+	}
+	if resp.GetRunner().GetName() != name {
+		t.Fatalf("expected runner name %q, got %q", name, resp.GetRunner().GetName())
+	}
+	if !reflect.DeepEqual(resp.GetRunner().GetLabels(), labels) {
+		t.Fatalf("expected labels %v, got %v", labels, resp.GetRunner().GetLabels())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestEnrollRunnerRequiresToken(t *testing.T) {
 	srv := New(Options{})
 
@@ -112,8 +288,9 @@ func TestEnrollRunnerSuccess(t *testing.T) {
 	runnerID := uuid.New()
 	identityID := uuid.New()
 	now := time.Now().UTC()
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, runnerStatusPending, now, now)
+	labelsJSON := []byte("{}")
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "labels", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, runnerStatusPending, labelsJSON, now, now)
 
 	token := "enroll-token"
 	mockPool.ExpectQuery(matcher).WithArgs(hashServiceToken(token)).WillReturnRows(rows)
@@ -178,8 +355,9 @@ func TestEnrollRunnerZitiFailure(t *testing.T) {
 	runnerID := uuid.New()
 	identityID := uuid.New()
 	now := time.Now().UTC()
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, runnerStatusPending, now, now)
+	labelsJSON := []byte("{}")
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "labels", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, runnerStatusPending, labelsJSON, now, now)
 
 	token := "bad-ziti"
 	mockPool.ExpectQuery(matcher).WithArgs(hashServiceToken(token)).WillReturnRows(rows)

--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
+	"maps"
 	"regexp"
 	"testing"
 	"time"
@@ -177,7 +177,7 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	if resp.GetRunner().GetName() != "runner-1" {
 		t.Fatalf("expected runner name %q, got %q", "runner-1", resp.GetRunner().GetName())
 	}
-	if !reflect.DeepEqual(resp.GetRunner().GetLabels(), labels) {
+	if !maps.Equal(resp.GetRunner().GetLabels(), labels) {
 		t.Fatalf("expected labels %v, got %v", labels, resp.GetRunner().GetLabels())
 	}
 	if resp.GetServiceToken() == "" {
@@ -212,9 +212,9 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "status", "labels", "created_at", "updated_at"}).
 		AddRow(runnerID, "runner-updated", pgtype.UUID{Valid: false}, identityID, runnerStatusOffline, labelsJSON, now, now)
 
-	matcher := regexp.QuoteMeta(fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = $2, updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns))
+	matcher := regexp.QuoteMeta(fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns))
 	mockPool.ExpectQuery(matcher).
-		WithArgs(pgtype.Text{String: "runner-updated", Valid: true}, labelsJSON, runnerID).
+		WithArgs(pgtype.Text{String: "runner-updated", Valid: true}, pgtype.Text{String: string(labelsJSON), Valid: true}, runnerID).
 		WillReturnRows(rows)
 
 	srv := New(Options{Pool: mockPool})
@@ -233,7 +233,7 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	if resp.GetRunner().GetName() != name {
 		t.Fatalf("expected runner name %q, got %q", name, resp.GetRunner().GetName())
 	}
-	if !reflect.DeepEqual(resp.GetRunner().GetLabels(), labels) {
+	if !maps.Equal(resp.GetRunner().GetLabels(), labels) {
 		t.Fatalf("expected labels %v, got %v", labels, resp.GetRunner().GetLabels())
 	}
 

--- a/migrations/0002_add_runner_labels.sql
+++ b/migrations/0002_add_runner_labels.sql
@@ -1,0 +1,2 @@
+ALTER TABLE runners
+ADD COLUMN labels JSONB NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary
- add runner labels migration and persistence
- include labels in register/update/read paths
- add label-focused runner handler tests

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

Closes #14