### PR TITLE
feat: add workload filters

### DIFF
--- a/.gen/go/agynio/api/runners/v1/runners.pb.go
+++ b/.gen/go/agynio/api/runners/v1/runners.pb.go
@@ -1782,12 +1782,14 @@ func (x *ListWorkloadsByThreadResponse) GetNextPageToken() string {
 }
 
 type ListWorkloadsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PageSize      int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	PageToken     string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
-	Statuses      []WorkloadStatus       `protobuf:"varint,3,rep,packed,name=statuses,proto3,enum=agynio.api.runners.v1.WorkloadStatus" json:"statuses,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	PageSize       int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	PageToken      string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	Statuses       []WorkloadStatus       `protobuf:"varint,3,rep,packed,name=statuses,proto3,enum=agynio.api.runners.v1.WorkloadStatus" json:"statuses,omitempty"`
+	OrganizationId *string                `protobuf:"bytes,4,opt,name=organization_id,json=organizationId,proto3,oneof" json:"organization_id,omitempty"`
+	RunnerId       *string                `protobuf:"bytes,5,opt,name=runner_id,json=runnerId,proto3,oneof" json:"runner_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ListWorkloadsRequest) Reset() {
@@ -1839,6 +1841,20 @@ func (x *ListWorkloadsRequest) GetStatuses() []WorkloadStatus {
 		return x.Statuses
 	}
 	return nil
+}
+
+func (x *ListWorkloadsRequest) GetOrganizationId() string {
+	if x != nil && x.OrganizationId != nil {
+		return *x.OrganizationId
+	}
+	return ""
+}
+
+func (x *ListWorkloadsRequest) GetRunnerId() string {
+	if x != nil && x.RunnerId != nil {
+		return *x.RunnerId
+	}
+	return ""
 }
 
 type ListWorkloadsResponse struct {
@@ -2019,12 +2035,17 @@ const file_agynio_api_runners_v1_runners_proto_rawDesc = "" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\"\x86\x01\n" +
 	"\x1dListWorkloadsByThreadResponse\x12=\n" +
 	"\tworkloads\x18\x01 \x03(\v2\x1f.agynio.api.runners.v1.WorkloadR\tworkloads\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x95\x01\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x87\x02\n" +
 	"\x14ListWorkloadsRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12A\n" +
-	"\bstatuses\x18\x03 \x03(\x0e2%.agynio.api.runners.v1.WorkloadStatusR\bstatuses\"~\n" +
+	"\bstatuses\x18\x03 \x03(\x0e2%.agynio.api.runners.v1.WorkloadStatusR\bstatuses\x12,\n" +
+	"\x0forganization_id\x18\x04 \x01(\tH\x00R\x0eorganizationId\x88\x01\x01\x12 \n" +
+	"\trunner_id\x18\x05 \x01(\tH\x01R\brunnerId\x88\x01\x01B\x12\n" +
+	"\x10_organization_idB\f\n" +
+	"\n" +
+	"_runner_id\"~\n" +
 	"\x15ListWorkloadsResponse\x12=\n" +
 	"\tworkloads\x18\x01 \x03(\v2\x1f.agynio.api.runners.v1.WorkloadR\tworkloads\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken*\x7f\n" +
@@ -2190,6 +2211,7 @@ func file_agynio_api_runners_v1_runners_proto_init() {
 	file_agynio_api_runners_v1_runners_proto_msgTypes[2].OneofWrappers = []any{}
 	file_agynio_api_runners_v1_runners_proto_msgTypes[6].OneofWrappers = []any{}
 	file_agynio_api_runners_v1_runners_proto_msgTypes[8].OneofWrappers = []any{}
+	file_agynio_api_runners_v1_runners_proto_msgTypes[28].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: b67ca28ce2c94ca1a95f27e18051641b
-    digest: shake256:fc939b54bfabac248969211ca6f70d6c4efe48c6e971644470c1a1eb2e49719208d270ce7b7319bace0ac279a1a8b2e842b146204a3d2600ab974c807c727ea3
+    commit: 5f499d593b034d2dac8d4dfaff62c8db
+    digest: shake256:d0d08ed0a5e950729cfa7df66965e90ffcda0f9ee8a9d8ad2dbf9389d9e620c4caf7e86f70572014008aeea43871b7976968e59e0afc3f8d64fc785fc0d2712d
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -201,7 +201,25 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
 	}
-	workloads, nextToken, err := s.listWorkloads(ctx, statuses, req.GetPageSize(), req.GetPageToken())
+	var organizationID *uuid.UUID
+	if req.OrganizationId != nil {
+		id, err := uuid.Parse(*req.OrganizationId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		organizationID = &id
+	}
+
+	var runnerID *uuid.UUID
+	if req.RunnerId != nil {
+		id, err := uuid.Parse(*req.RunnerId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
+		}
+		runnerID = &id
+	}
+
+	workloads, nextToken, err := s.listWorkloads(ctx, statuses, organizationID, runnerID, req.GetPageSize(), req.GetPageToken())
 	if err != nil {
 		var invalidToken *InvalidPageTokenError
 		if errors.As(err, &invalidToken) {
@@ -297,7 +315,7 @@ func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, 
 	})
 }
 
-func (s *Server) listWorkloads(ctx context.Context, statuses []string, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
+func (s *Server) listWorkloads(ctx context.Context, statuses []string, organizationID *uuid.UUID, runnerID *uuid.UUID, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
 	var (
 		clauses []string
 		args    []any
@@ -305,6 +323,14 @@ func (s *Server) listWorkloads(ctx context.Context, statuses []string, pageSize 
 	if len(statuses) > 0 {
 		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
 		args = append(args, pgtype.FlatArray[string](statuses))
+	}
+	if organizationID != nil {
+		clauses = append(clauses, fmt.Sprintf("organization_id = $%d", len(args)+1))
+		args = append(args, *organizationID)
+	}
+	if runnerID != nil {
+		clauses = append(clauses, fmt.Sprintf("runner_id = $%d", len(args)+1))
+		args = append(args, *runnerID)
 	}
 	return listWithPagination(ctx, s.pool, fmt.Sprintf("SELECT %s FROM workloads", workloadColumns), clauses, args, pageSize, pageToken, scanWorkload, func(record workloadRecord) uuid.UUID {
 		return record.Meta.ID

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -203,20 +203,20 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 	}
 	var organizationID *uuid.UUID
 	if req.OrganizationId != nil {
-		id, err := uuid.Parse(*req.OrganizationId)
+		parsed, err := parseUUID(req.GetOrganizationId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
-		organizationID = &id
+		organizationID = &parsed
 	}
 
 	var runnerID *uuid.UUID
 	if req.RunnerId != nil {
-		id, err := uuid.Parse(*req.RunnerId)
+		parsed, err := parseUUID(req.GetRunnerId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 		}
-		runnerID = &id
+		runnerID = &parsed
 	}
 
 	workloads, nextToken, err := s.listWorkloads(ctx, statuses, organizationID, runnerID, req.GetPageSize(), req.GetPageToken())

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var workloadRowColumns = []string{
+	"id",
+	"runner_id",
+	"thread_id",
+	"agent_id",
+	"organization_id",
+	"status",
+	"containers",
+	"ziti_identity_id",
+	"created_at",
+	"updated_at",
+}
+
+func TestListWorkloadsFiltersOrganization(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, 51).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	organizationIDValue := organizationID.String()
+	resp, err := srv.ListWorkloads(context.Background(), &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if resp.GetWorkloads()[0].GetOrganizationId() != organizationID.String() {
+		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetWorkloads()[0].GetOrganizationId())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsFiltersRunner(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(runnerID, 51).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	runnerIDValue := runnerID.String()
+	resp, err := srv.ListWorkloads(context.Background(), &runnersv1.ListWorkloadsRequest{RunnerId: &runnerIDValue})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if resp.GetWorkloads()[0].GetRunnerId() != runnerID.String() {
+		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetWorkloads()[0].GetRunnerId())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsNoFiltersReturnsAll(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	firstID := uuid.New()
+	secondID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(firstID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", now, now).
+		AddRow(secondID, runnerID, threadID, agentID, organizationID, workloadStatusStopped, containersJSON, "ziti-id", now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads ORDER BY id ASC LIMIT $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(51).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	resp, err := srv.ListWorkloads(context.Background(), &runnersv1.ListWorkloadsRequest{})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 2 {
+		t.Fatalf("expected 2 workloads, got %d", len(resp.GetWorkloads()))
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsInvalidUUID(t *testing.T) {
+	srv := New(Options{})
+
+	cases := []struct {
+		name string
+		req  *runnersv1.ListWorkloadsRequest
+	}{
+		{
+			name: "organization_id",
+			req: func() *runnersv1.ListWorkloadsRequest {
+				value := "not-a-uuid"
+				return &runnersv1.ListWorkloadsRequest{OrganizationId: &value}
+			}(),
+		},
+		{
+			name: "runner_id",
+			req: func() *runnersv1.ListWorkloadsRequest {
+				value := "not-a-uuid"
+				return &runnersv1.ListWorkloadsRequest{RunnerId: &value}
+			}(),
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := srv.ListWorkloads(context.Background(), testCase.req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected InvalidArgument error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- parse optional organization_id/runner_id filters in ListWorkloads and apply SQL clauses
- regenerate runners proto stubs from agynio/api PR #95 branch (buf.lock still targets b67ca28 until BSR updates)

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

## Issue
- #18