### PR TITLE
Fix batch sampled_at update casts

### DIFF
--- a/internal/server/sampled_at.go
+++ b/internal/server/sampled_at.go
@@ -25,7 +25,7 @@ func buildBatchSampledAtUpdateQuery(table string, entries []sampledAtEntry) (str
 			query.WriteString(", ")
 		}
 		argPos := len(args) + 1
-		fmt.Fprintf(&query, "($%d, $%d)", argPos, argPos+1)
+		fmt.Fprintf(&query, "($%d::uuid, $%d::timestamptz)", argPos, argPos+1)
 		args = append(args, entry.ID, entry.SampledAt)
 	}
 	query.WriteString(") AS v(id, sampled_at) WHERE target.id = v.id")

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -242,7 +242,7 @@ func TestBatchUpdateVolumeSampledAt(t *testing.T) {
 	firstSampledAt := time.Now().UTC()
 	secondSampledAt := firstSampledAt.Add(3 * time.Minute)
 
-	query := "UPDATE volumes AS target SET last_metering_sampled_at = v.sampled_at, updated_at = NOW() FROM (VALUES ($1, $2), ($3, $4)) AS v(id, sampled_at) WHERE target.id = v.id"
+	query := "UPDATE volumes AS target SET last_metering_sampled_at = v.sampled_at, updated_at = NOW() FROM (VALUES ($1::uuid, $2::timestamptz), ($3::uuid, $4::timestamptz)) AS v(id, sampled_at) WHERE target.id = v.id"
 	mockPool.ExpectExec(regexp.QuoteMeta(query)).
 		WithArgs(firstID, firstSampledAt, secondID, secondSampledAt).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 2))

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -284,7 +284,7 @@ func TestBatchUpdateWorkloadSampledAt(t *testing.T) {
 	firstSampledAt := time.Now().UTC()
 	secondSampledAt := firstSampledAt.Add(2 * time.Minute)
 
-	query := "UPDATE workloads AS target SET last_metering_sampled_at = v.sampled_at, updated_at = NOW() FROM (VALUES ($1, $2), ($3, $4)) AS v(id, sampled_at) WHERE target.id = v.id"
+	query := "UPDATE workloads AS target SET last_metering_sampled_at = v.sampled_at, updated_at = NOW() FROM (VALUES ($1::uuid, $2::timestamptz), ($3::uuid, $4::timestamptz)) AS v(id, sampled_at) WHERE target.id = v.id"
 	mockPool.ExpectExec(regexp.QuoteMeta(query)).
 		WithArgs(firstID, firstSampledAt, secondID, secondSampledAt).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 2))


### PR DESCRIPTION
## Summary
- add explicit uuid/timestamptz casts in batch sampled_at updates
- update batch sampled_at query expectations in tests

## Testing
- go test ./...
- go vet ./...

Closes #27