### PR TITLE
feat(runners): persist runner capabilities

### DIFF
--- a/.gen/go/agynio/api/runners/v1/runners.pb.go
+++ b/.gen/go/agynio/api/runners/v1/runners.pb.go
@@ -416,8 +416,10 @@ type Runner struct {
 	Labels         map[string]string      `protobuf:"bytes,6,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Per-runner OpenZiti service name (e.g. "runner-{id}")
 	OpenzitiServiceName string `protobuf:"bytes,7,opt,name=openziti_service_name,json=openzitiServiceName,proto3" json:"openziti_service_name,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
+	Capabilities  []string `protobuf:"bytes,8,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Runner) Reset() {
@@ -499,13 +501,22 @@ func (x *Runner) GetOpenzitiServiceName() string {
 	return ""
 }
 
+func (x *Runner) GetCapabilities() []string {
+	if x != nil {
+		return x.Capabilities
+	}
+	return nil
+}
+
 type RegisterRunnerRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Name           string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	OrganizationId *string                `protobuf:"bytes,2,opt,name=organization_id,json=organizationId,proto3,oneof" json:"organization_id,omitempty"`
 	Labels         map[string]string      `protobuf:"bytes,3,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
+	Capabilities  []string `protobuf:"bytes,4,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RegisterRunnerRequest) Reset() {
@@ -555,6 +566,13 @@ func (x *RegisterRunnerRequest) GetOrganizationId() string {
 func (x *RegisterRunnerRequest) GetLabels() map[string]string {
 	if x != nil {
 		return x.Labels
+	}
+	return nil
+}
+
+func (x *RegisterRunnerRequest) GetCapabilities() []string {
+	if x != nil {
+		return x.Capabilities
 	}
 	return nil
 }
@@ -816,7 +834,9 @@ type UpdateRunnerRequest struct {
 	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Name  *string                `protobuf:"bytes,2,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	// Labels replace the existing map; omitted keys are removed.
-	Labels        map[string]string `protobuf:"bytes,3,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels map[string]string `protobuf:"bytes,3,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Capabilities replace the existing list; an empty list clears all capabilities.
+	Capabilities  []string `protobuf:"bytes,4,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -868,6 +888,13 @@ func (x *UpdateRunnerRequest) GetName() string {
 func (x *UpdateRunnerRequest) GetLabels() map[string]string {
 	if x != nil {
 		return x.Labels
+	}
+	return nil
+}
+
+func (x *UpdateRunnerRequest) GetCapabilities() []string {
+	if x != nil {
+		return x.Capabilities
 	}
 	return nil
 }
@@ -3199,7 +3226,7 @@ const file_agynio_api_runners_v1_runners_proto_rawDesc = "" +
 	"\x0eSampledAtEntry\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
-	"sampled_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tsampledAt\"\xa5\x03\n" +
+	"sampled_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tsampledAt\"\xc9\x03\n" +
 	"\x06Runner\x125\n" +
 	"\x04meta\x18\x01 \x01(\v2!.agynio.api.runners.v1.EntityMetaR\x04meta\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12,\n" +
@@ -3208,15 +3235,17 @@ const file_agynio_api_runners_v1_runners_proto_rawDesc = "" +
 	"identityId\x12;\n" +
 	"\x06status\x18\x05 \x01(\x0e2#.agynio.api.runners.v1.RunnerStatusR\x06status\x12A\n" +
 	"\x06labels\x18\x06 \x03(\v2).agynio.api.runners.v1.Runner.LabelsEntryR\x06labels\x122\n" +
-	"\x15openziti_service_name\x18\a \x01(\tR\x13openzitiServiceName\x1a9\n" +
+	"\x15openziti_service_name\x18\a \x01(\tR\x13openzitiServiceName\x12\"\n" +
+	"\fcapabilities\x18\b \x03(\tR\fcapabilities\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x12\n" +
-	"\x10_organization_id\"\xfa\x01\n" +
+	"\x10_organization_id\"\x9e\x02\n" +
 	"\x15RegisterRunnerRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12,\n" +
 	"\x0forganization_id\x18\x02 \x01(\tH\x00R\x0eorganizationId\x88\x01\x01\x12P\n" +
-	"\x06labels\x18\x03 \x03(\v28.agynio.api.runners.v1.RegisterRunnerRequest.LabelsEntryR\x06labels\x1a9\n" +
+	"\x06labels\x18\x03 \x03(\v28.agynio.api.runners.v1.RegisterRunnerRequest.LabelsEntryR\x06labels\x12\"\n" +
+	"\fcapabilities\x18\x04 \x03(\tR\fcapabilities\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x12\n" +
@@ -3236,11 +3265,12 @@ const file_agynio_api_runners_v1_runners_proto_rawDesc = "" +
 	"\x10_organization_id\"v\n" +
 	"\x13ListRunnersResponse\x127\n" +
 	"\arunners\x18\x01 \x03(\v2\x1d.agynio.api.runners.v1.RunnerR\arunners\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xd2\x01\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xf6\x01\n" +
 	"\x13UpdateRunnerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
 	"\x04name\x18\x02 \x01(\tH\x00R\x04name\x88\x01\x01\x12N\n" +
-	"\x06labels\x18\x03 \x03(\v26.agynio.api.runners.v1.UpdateRunnerRequest.LabelsEntryR\x06labels\x1a9\n" +
+	"\x06labels\x18\x03 \x03(\v26.agynio.api.runners.v1.UpdateRunnerRequest.LabelsEntryR\x06labels\x12\"\n" +
+	"\fcapabilities\x18\x04 \x03(\tR\fcapabilities\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\a\n" +

--- a/.gen/go/agynio/api/ziti_management/v1/ziti_management.pb.go
+++ b/.gen/go/agynio/api/ziti_management/v1/ziti_management.pb.go
@@ -30,6 +30,7 @@ const (
 	ServiceType_SERVICE_TYPE_GATEWAY      ServiceType = 1
 	ServiceType_SERVICE_TYPE_ORCHESTRATOR ServiceType = 2
 	ServiceType_SERVICE_TYPE_LLM_PROXY    ServiceType = 4
+	ServiceType_SERVICE_TYPE_TRACING      ServiceType = 5
 )
 
 // Enum value maps for ServiceType.
@@ -39,12 +40,14 @@ var (
 		1: "SERVICE_TYPE_GATEWAY",
 		2: "SERVICE_TYPE_ORCHESTRATOR",
 		4: "SERVICE_TYPE_LLM_PROXY",
+		5: "SERVICE_TYPE_TRACING",
 	}
 	ServiceType_value = map[string]int32{
 		"SERVICE_TYPE_UNSPECIFIED":  0,
 		"SERVICE_TYPE_GATEWAY":      1,
 		"SERVICE_TYPE_ORCHESTRATOR": 2,
 		"SERVICE_TYPE_LLM_PROXY":    4,
+		"SERVICE_TYPE_TRACING":      5,
 	}
 )
 
@@ -2061,12 +2064,13 @@ const file_agynio_api_ziti_management_v1_ziti_management_proto_rawDesc = "" +
 	"\x0eenrollment_jwt\x18\x02 \x01(\tR\renrollmentJwt\"G\n" +
 	"\x1bDeleteDeviceIdentityRequest\x12(\n" +
 	"\x10ziti_identity_id\x18\x01 \x01(\tR\x0ezitiIdentityId\"\x1e\n" +
-	"\x1cDeleteDeviceIdentityResponse*\x9b\x01\n" +
+	"\x1cDeleteDeviceIdentityResponse*\xb5\x01\n" +
 	"\vServiceType\x12\x1c\n" +
 	"\x18SERVICE_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14SERVICE_TYPE_GATEWAY\x10\x01\x12\x1d\n" +
 	"\x19SERVICE_TYPE_ORCHESTRATOR\x10\x02\x12\x1a\n" +
-	"\x16SERVICE_TYPE_LLM_PROXY\x10\x04\"\x04\b\x03\x10\x03*\x13SERVICE_TYPE_RUNNER*t\n" +
+	"\x16SERVICE_TYPE_LLM_PROXY\x10\x04\x12\x18\n" +
+	"\x14SERVICE_TYPE_TRACING\x10\x05\"\x04\b\x03\x10\x03*\x13SERVICE_TYPE_RUNNER*t\n" +
 	"\x11ServicePolicyType\x12#\n" +
 	"\x1fSERVICE_POLICY_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SERVICE_POLICY_TYPE_BIND\x10\x01\x12\x1c\n" +

--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 8d4dc9a8133f4963a67ed84b3f6ca45f
-    digest: shake256:8fbacb396f9ef5bff102f4ec526801d3f1bf2bf29ecfbdcf76b5a257c6c4cdcd8717d12f3609c28cbb7bd0eeafa359da816fb98820e2afa6c9d048ce8ced7c90
+    commit: f3017f9d17f34204bb16b2d4965e8e58
+    digest: shake256:d7a844b0d81eb46525351d250d8b7df473f5dd907aa1b1e26273cf27fab84f0edde9844c07924e86f1f7583ed5204371aa1647f7d09165563973b0228206c086
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/server/runners.go
+++ b/internal/server/runners.go
@@ -28,7 +28,7 @@ const (
 	zitiRunnerRoleAttribute = "runners"
 	zitiRunnerServiceRole   = "runner-services"
 
-	runnerColumns = `id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, status, labels, created_at, updated_at`
+	runnerColumns = `id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, status, labels, capabilities, created_at, updated_at`
 )
 
 type runnerRecord struct {
@@ -41,6 +41,7 @@ type runnerRecord struct {
 	ZitiServiceName string
 	Status          string
 	Labels          map[string]string
+	Capabilities    []string
 }
 
 type runnerInsertInput struct {
@@ -54,12 +55,39 @@ type runnerInsertInput struct {
 	ServiceTokenHash string
 	Status           string
 	Labels           map[string]string
+	Capabilities     []string
 }
 
 type runnerUpdateInput struct {
-	ID     uuid.UUID
-	Name   *string
-	Labels *map[string]string
+	ID           uuid.UUID
+	Name         *string
+	Labels       *map[string]string
+	Capabilities *[]string
+}
+
+func decodeCapabilities(value []byte) ([]string, error) {
+	if value == nil {
+		return nil, fmt.Errorf("capabilities is NULL")
+	}
+	var capabilities []string
+	if err := json.Unmarshal(value, &capabilities); err != nil {
+		return nil, fmt.Errorf("decode capabilities: %w", err)
+	}
+	if capabilities == nil {
+		return nil, fmt.Errorf("capabilities must be a JSON array")
+	}
+	return capabilities, nil
+}
+
+func encodeCapabilities(capabilities []string) ([]byte, error) {
+	if capabilities == nil {
+		capabilities = []string{}
+	}
+	data, err := json.Marshal(capabilities)
+	if err != nil {
+		return nil, fmt.Errorf("encode capabilities: %w", err)
+	}
+	return data, nil
 }
 
 func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunnerRequest) (*runnersv1.RegisterRunnerResponse, error) {
@@ -71,6 +99,7 @@ func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunn
 	if labels == nil {
 		labels = map[string]string{}
 	}
+	capabilities := append([]string(nil), req.GetCapabilities()...)
 
 	var organizationID *uuid.UUID
 	if req.OrganizationId != nil {
@@ -121,6 +150,7 @@ func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunn
 		ServiceTokenHash: tokenHash,
 		Status:           runnerStatusPending,
 		Labels:           labels,
+		Capabilities:     capabilities,
 	})
 	if err != nil {
 		s.cleanupRunnerAuthorization(ctx, runnerID, organizationID)
@@ -170,8 +200,17 @@ func (s *Server) UpdateRunner(ctx context.Context, req *runnersv1.UpdateRunnerRe
 		value := req.Labels
 		labels = &value
 	}
+	// NOTE: proto3 repeated fields do not track presence on the wire. A nil
+	// slice indicates the caller did not set capabilities; when provided, the
+	// list replaces existing capabilities.
+	capabilitiesProvided := req.Capabilities != nil
+	var capabilities *[]string
+	if capabilitiesProvided {
+		value := append([]string(nil), req.GetCapabilities()...)
+		capabilities = &value
+	}
 
-	runner, err := s.updateRunner(ctx, runnerUpdateInput{ID: id, Name: name, Labels: labels})
+	runner, err := s.updateRunner(ctx, runnerUpdateInput{ID: id, Name: name, Labels: labels, Capabilities: capabilities})
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -321,9 +360,13 @@ func (s *Server) insertRunner(ctx context.Context, input runnerInsertInput) (run
 	if err != nil {
 		return runnerRecord{}, err
 	}
+	capabilitiesJSON, err := encodeCapabilities(input.Capabilities)
+	if err != nil {
+		return runnerRecord{}, err
+	}
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO runners (id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, service_token_hash, status, labels)
-	    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		fmt.Sprintf(`INSERT INTO runners (id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, service_token_hash, status, labels, capabilities)
+	    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	    RETURNING %s`, runnerColumns),
 		input.ID,
 		input.Name,
@@ -335,6 +378,7 @@ func (s *Server) insertRunner(ctx context.Context, input runnerInsertInput) (run
 		input.ServiceTokenHash,
 		input.Status,
 		labelsJSON,
+		capabilitiesJSON,
 	)
 	runner, err := scanRunner(row)
 	if err != nil {
@@ -419,15 +463,25 @@ func (s *Server) updateRunner(ctx context.Context, input runnerUpdateInput) (run
 		labelsValue = pgtype.Text{String: string(labelsJSON), Valid: true}
 	}
 
+	capabilitiesValue := pgtype.Text{Valid: false}
+	if input.Capabilities != nil {
+		capabilitiesJSON, err := encodeCapabilities(*input.Capabilities)
+		if err != nil {
+			return runnerRecord{}, err
+		}
+		capabilitiesValue = pgtype.Text{String: string(capabilitiesJSON), Valid: true}
+	}
+
 	nameValue := pgtype.Text{Valid: false}
 	if input.Name != nil {
 		nameValue = pgtype.Text{String: *input.Name, Valid: true}
 	}
 
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns),
+		fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), capabilities = COALESCE($3::jsonb, capabilities), updated_at = NOW() WHERE id = $4 RETURNING %s`, runnerColumns),
 		nameValue,
 		labelsValue,
+		capabilitiesValue,
 		input.ID,
 	)
 	runner, err := scanRunner(row)
@@ -456,6 +510,7 @@ func scanRunner(row pgx.Row) (runnerRecord, error) {
 		runner     runnerRecord
 		orgID      pgtype.UUID
 		labelsData []byte
+		capData    []byte
 	)
 	if err := row.Scan(
 		&runner.Meta.ID,
@@ -467,6 +522,7 @@ func scanRunner(row pgx.Row) (runnerRecord, error) {
 		&runner.ZitiServiceName,
 		&runner.Status,
 		&labelsData,
+		&capData,
 		&runner.Meta.CreatedAt,
 		&runner.Meta.UpdatedAt,
 	); err != nil {
@@ -478,6 +534,11 @@ func scanRunner(row pgx.Row) (runnerRecord, error) {
 	if runner.Labels == nil {
 		runner.Labels = map[string]string{}
 	}
+	capabilities, err := decodeCapabilities(capData)
+	if err != nil {
+		return runnerRecord{}, err
+	}
+	runner.Capabilities = capabilities
 	if orgID.Valid {
 		value := uuid.UUID(orgID.Bytes)
 		runner.OrganizationID = &value
@@ -496,6 +557,7 @@ func toProtoRunner(record runnerRecord) (*runnersv1.Runner, error) {
 		IdentityId:          record.IdentityID.String(),
 		Status:              status,
 		Labels:              record.Labels,
+		Capabilities:        append([]string(nil), record.Capabilities...),
 		OpenzitiServiceName: record.ZitiServiceName,
 	}
 	if record.OrganizationID != nil {

--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"slices"
 	"testing"
 	"time"
 
@@ -175,18 +176,23 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to marshal labels: %v", err)
 	}
+	capabilities := []string{"gpu", "docker"}
+	capabilitiesJSON, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("failed to marshal capabilities: %v", err)
+	}
 
 	runnerID := uuid.New()
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	zitiServiceID := "service-id"
 	zitiServiceName := "runner-service"
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", zitiServiceID, zitiServiceName, runnerStatusPending, labelsJSON, now, now)
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", zitiServiceID, zitiServiceName, runnerStatusPending, labelsJSON, capabilitiesJSON, now, now)
 
-	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO runners (id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, service_token_hash, status, labels)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)\n\t    RETURNING %s", runnerColumns))
+	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO runners (id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, service_token_hash, status, labels, capabilities)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n\t    RETURNING %s", runnerColumns))
 	mockPool.ExpectQuery(matcher).
-		WithArgs(pgxmock.AnyArg(), "runner-1", pgxmock.AnyArg(), pgxmock.AnyArg(), "", zitiServiceID, zitiServiceName, pgxmock.AnyArg(), runnerStatusPending, labelsJSON).
+		WithArgs(pgxmock.AnyArg(), "runner-1", pgxmock.AnyArg(), pgxmock.AnyArg(), "", zitiServiceID, zitiServiceName, pgxmock.AnyArg(), runnerStatusPending, labelsJSON, capabilitiesJSON).
 		WillReturnRows(rows)
 
 	var gotIdentityReq *identityv1.RegisterIdentityRequest
@@ -222,8 +228,9 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	})
 
 	resp, err := srv.RegisterRunner(context.Background(), &runnersv1.RegisterRunnerRequest{
-		Name:   "runner-1",
-		Labels: labels,
+		Name:         "runner-1",
+		Labels:       labels,
+		Capabilities: capabilities,
 	})
 	if err != nil {
 		t.Fatalf("RegisterRunner failed: %v", err)
@@ -236,6 +243,9 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	}
 	if !maps.Equal(resp.GetRunner().GetLabels(), labels) {
 		t.Fatalf("expected labels %v, got %v", labels, resp.GetRunner().GetLabels())
+	}
+	if !slices.Equal(resp.GetRunner().GetCapabilities(), capabilities) {
+		t.Fatalf("expected capabilities %v, got %v", capabilities, resp.GetRunner().GetCapabilities())
 	}
 	if resp.GetServiceToken() == "" {
 		t.Fatal("expected service token")
@@ -274,21 +284,32 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to marshal labels: %v", err)
 	}
+	capabilities := []string{"containerd", "gpu"}
+	capabilitiesJSON, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("failed to marshal capabilities: %v", err)
+	}
 	now := time.Now().UTC()
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-updated", pgtype.UUID{Valid: false}, identityID, "", "service-id", "runner-service", runnerStatusOffline, labelsJSON, now, now)
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-updated", pgtype.UUID{Valid: false}, identityID, "", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
 
-	matcher := regexp.QuoteMeta(fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), updated_at = NOW() WHERE id = $3 RETURNING %s`, runnerColumns))
+	matcher := regexp.QuoteMeta(fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), capabilities = COALESCE($3::jsonb, capabilities), updated_at = NOW() WHERE id = $4 RETURNING %s`, runnerColumns))
 	mockPool.ExpectQuery(matcher).
-		WithArgs(pgtype.Text{String: "runner-updated", Valid: true}, pgtype.Text{String: string(labelsJSON), Valid: true}, runnerID).
+		WithArgs(
+			pgtype.Text{String: "runner-updated", Valid: true},
+			pgtype.Text{String: string(labelsJSON), Valid: true},
+			pgtype.Text{String: string(capabilitiesJSON), Valid: true},
+			runnerID,
+		).
 		WillReturnRows(rows)
 
 	srv := New(Options{Pool: mockPool})
 	name := "runner-updated"
 	resp, err := srv.UpdateRunner(context.Background(), &runnersv1.UpdateRunnerRequest{
-		Id:     runnerID.String(),
-		Name:   &name,
-		Labels: labels,
+		Id:           runnerID.String(),
+		Name:         &name,
+		Labels:       labels,
+		Capabilities: capabilities,
 	})
 	if err != nil {
 		t.Fatalf("UpdateRunner failed: %v", err)
@@ -301,6 +322,9 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	}
 	if !maps.Equal(resp.GetRunner().GetLabels(), labels) {
 		t.Fatalf("expected labels %v, got %v", labels, resp.GetRunner().GetLabels())
+	}
+	if !slices.Equal(resp.GetRunner().GetCapabilities(), capabilities) {
+		t.Fatalf("expected capabilities %v, got %v", capabilities, resp.GetRunner().GetCapabilities())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -355,9 +379,10 @@ func TestEnrollRunnerSuccess(t *testing.T) {
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	labelsJSON := []byte("{}")
+	capabilitiesJSON := []byte("[]")
 	serviceName := "runner-service"
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", "service-id", serviceName, runnerStatusPending, labelsJSON, now, now)
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", "service-id", serviceName, runnerStatusPending, labelsJSON, capabilitiesJSON, now, now)
 
 	token := "enroll-token"
 	mockPool.ExpectQuery(matcher).WithArgs(hashServiceToken(token)).WillReturnRows(rows)
@@ -420,8 +445,9 @@ func TestEnrollRunnerZitiFailure(t *testing.T) {
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	labelsJSON := []byte("{}")
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", "service-id", "runner-service", runnerStatusPending, labelsJSON, now, now)
+	capabilitiesJSON := []byte("[]")
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", "service-id", "runner-service", runnerStatusPending, labelsJSON, capabilitiesJSON, now, now)
 
 	token := "bad-ziti"
 	mockPool.ExpectQuery(matcher).WithArgs(hashServiceToken(token)).WillReturnRows(rows)
@@ -460,11 +486,12 @@ func TestDeleteRunnerCallsZitiCleanup(t *testing.T) {
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	labelsJSON := []byte("{}")
+	capabilitiesJSON := []byte("[]")
 	zitiServiceID := "service-id"
 	zitiServiceName := "runner-service"
 	zitiIdentityID := "ziti-identity"
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, zitiIdentityID, zitiServiceID, zitiServiceName, runnerStatusOffline, labelsJSON, now, now)
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, zitiIdentityID, zitiServiceID, zitiServiceName, runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
 
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(runnerID).WillReturnRows(rows)
 	mockPool.ExpectExec(deleteQuery).WithArgs(runnerID).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -522,8 +549,9 @@ func TestDeleteRunnerBestEffortZitiFailure(t *testing.T) {
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	labelsJSON := []byte("{}")
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "ziti-identity", "service-id", "runner-service", runnerStatusOffline, labelsJSON, now, now)
+	capabilitiesJSON := []byte("[]")
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "ziti-identity", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
 
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(runnerID).WillReturnRows(rows)
 	mockPool.ExpectExec(deleteQuery).WithArgs(runnerID).WillReturnResult(pgxmock.NewResult("DELETE", 1))

--- a/migrations/0006_add_runner_capabilities.sql
+++ b/migrations/0006_add_runner_capabilities.sql
@@ -1,0 +1,2 @@
+ALTER TABLE runners
+ADD COLUMN capabilities JSONB NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Summary
- bump agynio/api buf dependency and regenerate bindings
- add runners capabilities column and JSONB persistence
- map runner capabilities through register/update responses with proto3 semantics
- update runner server tests for capabilities

## Testing
- go test ./...
- go build ./...

Fixes #133