### PR TITLE
feat(authz): enforce runners authorization

### DIFF
--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func identityFromMetadata(ctx context.Context) (uuid.UUID, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.UUID{}, fmt.Errorf("metadata missing")
+	}
+	values := md.Get(identityMetadata)
+	if len(values) != 1 {
+		return uuid.UUID{}, fmt.Errorf("expected single value")
+	}
+	return parseUUID(values[0])
+}
+
+func (s *Server) requireClusterAdmin(ctx context.Context, identityID uuid.UUID) error {
+	return s.requireRelation(ctx, identityID, clusterAdminRelation, clusterObject)
+}
+
+func (s *Server) requireOrgOwner(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
+	return s.requireRelation(ctx, identityID, organizationOwnerRelation, organizationObject(organizationID))
+}
+
+func (s *Server) requireOrgMember(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
+	return s.requireRelation(ctx, identityID, organizationMemberRelation, organizationObject(organizationID))
+}
+
+func (s *Server) orgRelationAllowed(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) (bool, error) {
+	return s.relationAllowed(ctx, identityID, relation, organizationObject(organizationID))
+}
+
+func (s *Server) relationAllowed(ctx context.Context, identityID uuid.UUID, relation string, object string) (bool, error) {
+	resp, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     identityObject(identityID),
+			Relation: relation,
+			Object:   object,
+		},
+	})
+	if err != nil {
+		return false, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	return resp.GetAllowed(), nil
+}
+
+func (s *Server) requireRelation(ctx context.Context, identityID uuid.UUID, relation string, object string) error {
+	allowed, err := s.relationAllowed(ctx, identityID, relation, object)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return nil
+}
+
+func (s *Server) memberAllowed(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, cache map[uuid.UUID]bool) (bool, error) {
+	if allowed, ok := cache[organizationID]; ok {
+		return allowed, nil
+	}
+	allowed, err := s.orgRelationAllowed(ctx, identityID, organizationID, organizationMemberRelation)
+	if err != nil {
+		return false, err
+	}
+	cache[organizationID] = allowed
+	return allowed, nil
+}

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -24,6 +24,12 @@ func (e *AlreadyExistsError) Error() string {
 	return fmt.Sprintf("%s already exists", e.Resource)
 }
 
+type PermissionDeniedError struct{}
+
+func (e *PermissionDeniedError) Error() string {
+	return "permission denied"
+}
+
 type InvalidPageTokenError struct {
 	Err error
 }
@@ -44,6 +50,10 @@ func AlreadyExists(resource string) error {
 	return &AlreadyExistsError{Resource: resource}
 }
 
+func PermissionDenied() error {
+	return &PermissionDeniedError{}
+}
+
 func InvalidPageToken(err error) error {
 	return &InvalidPageTokenError{Err: err}
 }
@@ -56,6 +66,10 @@ func toStatusError(err error) error {
 	var exists *AlreadyExistsError
 	if errors.As(err, &exists) {
 		return status.Error(codes.AlreadyExists, exists.Error())
+	}
+	var denied *PermissionDeniedError
+	if errors.As(err, &denied) {
+		return status.Error(codes.PermissionDenied, denied.Error())
 	}
 	return status.Errorf(codes.Internal, "internal error: %v", err)
 }

--- a/internal/server/runners.go
+++ b/internal/server/runners.go
@@ -91,6 +91,10 @@ func encodeCapabilities(capabilities []string) ([]byte, error) {
 }
 
 func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunnerRequest) (*runnersv1.RegisterRunnerResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	name := strings.TrimSpace(req.GetName())
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "name must be provided")
@@ -108,6 +112,14 @@ func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunn
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
 		organizationID = &parsed
+	}
+
+	if organizationID == nil {
+		if err := s.requireClusterAdmin(ctx, callerID); err != nil {
+			return nil, err
+		}
+	} else if err := s.requireOrgOwner(ctx, callerID, *organizationID); err != nil {
+		return nil, err
 	}
 
 	runnerID := uuid.New()
@@ -165,6 +177,10 @@ func (s *Server) RegisterRunner(ctx context.Context, req *runnersv1.RegisterRunn
 }
 
 func (s *Server) GetRunner(ctx context.Context, req *runnersv1.GetRunnerRequest) (*runnersv1.GetRunnerResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -172,6 +188,11 @@ func (s *Server) GetRunner(ctx context.Context, req *runnersv1.GetRunnerRequest)
 	runner, err := s.getRunnerByID(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if runner.OrganizationID != nil {
+		if err := s.requireOrgMember(ctx, callerID, *runner.OrganizationID); err != nil {
+			return nil, err
+		}
 	}
 	protoRunner, err := toProtoRunner(runner)
 	if err != nil {
@@ -181,6 +202,10 @@ func (s *Server) GetRunner(ctx context.Context, req *runnersv1.GetRunnerRequest)
 }
 
 func (s *Server) UpdateRunner(ctx context.Context, req *runnersv1.UpdateRunnerRequest) (*runnersv1.UpdateRunnerResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -210,6 +235,18 @@ func (s *Server) UpdateRunner(ctx context.Context, req *runnersv1.UpdateRunnerRe
 		capabilities = &value
 	}
 
+	runnerRecord, err := s.getRunnerByID(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if runnerRecord.OrganizationID == nil {
+		if err := s.requireClusterAdmin(ctx, callerID); err != nil {
+			return nil, err
+		}
+	} else if err := s.requireOrgOwner(ctx, callerID, *runnerRecord.OrganizationID); err != nil {
+		return nil, err
+	}
+
 	runner, err := s.updateRunner(ctx, runnerUpdateInput{ID: id, Name: name, Labels: labels, Capabilities: capabilities})
 	if err != nil {
 		return nil, toStatusError(err)
@@ -222,6 +259,10 @@ func (s *Server) UpdateRunner(ctx context.Context, req *runnersv1.UpdateRunnerRe
 }
 
 func (s *Server) ListRunners(ctx context.Context, req *runnersv1.ListRunnersRequest) (*runnersv1.ListRunnersResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	var organizationID *uuid.UUID
 	if req.OrganizationId != nil {
 		parsed, err := parseUUID(req.GetOrganizationId())
@@ -229,6 +270,11 @@ func (s *Server) ListRunners(ctx context.Context, req *runnersv1.ListRunnersRequ
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
 		organizationID = &parsed
+	}
+	if organizationID != nil {
+		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
+			return nil, err
+		}
 	}
 
 	runners, nextToken, err := s.listRunners(ctx, organizationID, req.GetPageSize(), req.GetPageToken())
@@ -238,6 +284,25 @@ func (s *Server) ListRunners(ctx context.Context, req *runnersv1.ListRunnersRequ
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", invalidToken.Err)
 		}
 		return nil, status.Errorf(codes.Internal, "list runners: %v", err)
+	}
+
+	if organizationID == nil {
+		memberCache := map[uuid.UUID]bool{}
+		filtered := make([]runnerRecord, 0, len(runners))
+		for _, runner := range runners {
+			if runner.OrganizationID == nil {
+				filtered = append(filtered, runner)
+				continue
+			}
+			allowed, err := s.memberAllowed(ctx, callerID, *runner.OrganizationID, memberCache)
+			if err != nil {
+				return nil, err
+			}
+			if allowed {
+				filtered = append(filtered, runner)
+			}
+		}
+		runners = filtered
 	}
 
 	protoRunners := make([]*runnersv1.Runner, 0, len(runners))
@@ -252,6 +317,10 @@ func (s *Server) ListRunners(ctx context.Context, req *runnersv1.ListRunnersRequ
 }
 
 func (s *Server) DeleteRunner(ctx context.Context, req *runnersv1.DeleteRunnerRequest) (*runnersv1.DeleteRunnerResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -260,6 +329,13 @@ func (s *Server) DeleteRunner(ctx context.Context, req *runnersv1.DeleteRunnerRe
 	runner, err := s.getRunnerByID(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if runner.OrganizationID == nil {
+		if err := s.requireClusterAdmin(ctx, callerID); err != nil {
+			return nil, err
+		}
+	} else if err := s.requireOrgOwner(ctx, callerID, *runner.OrganizationID); err != nil {
+		return nil, err
 	}
 
 	if runner.ZitiServiceID != "" || runner.ZitiIdentityID != "" {
@@ -329,6 +405,9 @@ func (s *Server) EnrollRunner(ctx context.Context, req *runnersv1.EnrollRunnerRe
 
 func (s *Server) writeRunnerAuthorization(ctx context.Context, runnerID uuid.UUID, organizationID *uuid.UUID) error {
 	tuple := runnerAuthorizationTuple(runnerID, organizationID)
+	if tuple == nil {
+		return nil
+	}
 	if _, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{Writes: []*authorizationv1.TupleKey{tuple}}); err != nil {
 		return status.Errorf(codes.Internal, "authorization write: %v", err)
 	}
@@ -337,6 +416,9 @@ func (s *Server) writeRunnerAuthorization(ctx context.Context, runnerID uuid.UUI
 
 func (s *Server) cleanupRunnerAuthorization(ctx context.Context, runnerID uuid.UUID, organizationID *uuid.UUID) {
 	tuple := runnerAuthorizationTuple(runnerID, organizationID)
+	if tuple == nil {
+		return
+	}
 	_, _ = s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{Deletes: []*authorizationv1.TupleKey{tuple}})
 }
 
@@ -348,11 +430,7 @@ func runnerAuthorizationTuple(runnerID uuid.UUID, organizationID *uuid.UUID) *au
 			Object:   organizationObject(*organizationID),
 		}
 	}
-	return &authorizationv1.TupleKey{
-		User:     identityObject(runnerID),
-		Relation: clusterWriterRelation,
-		Object:   clusterObject,
-	}
+	return nil
 }
 
 func (s *Server) insertRunner(ctx context.Context, input runnerInsertInput) (runnerRecord, error) {

--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -400,6 +400,71 @@ func TestRegisterRunnerClusterScopedRequiresAdmin(t *testing.T) {
 	}
 }
 
+func TestGetRunnerRequiresMember(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	runnerID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	now := time.Now().UTC()
+	labelsJSON := []byte("{}")
+	capabilitiesJSON := []byte("[]")
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Bytes: organizationID, Valid: true}, identityID, "", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
+
+	query := fmt.Sprintf(`SELECT %s FROM runners WHERE id = $1`, runnerColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(runnerID).WillReturnRows(rows)
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.GetRunner(ctx, &runnersv1.GetRunnerRequest{Id: runnerID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListRunnersRequiresMember(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	organizationID := uuid.New()
+	callerID := uuid.New()
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.ListRunners(ctx, &runnersv1.ListRunnersRequest{OrganizationId: &organizationIDValue})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {

--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pashagolub/pgxmock/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -135,11 +136,15 @@ func (f fakeIdentityClient) ResolveNickname(ctx context.Context, req *identityv1
 }
 
 type fakeAuthorizationClient struct {
+	check func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error)
 	write func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error)
 }
 
 func (f fakeAuthorizationClient) Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+	if f.check == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.check(ctx, req)
 }
 
 func (f fakeAuthorizationClient) BatchCheck(ctx context.Context, req *authorizationv1.BatchCheckRequest, opts ...grpc.CallOption) (*authorizationv1.BatchCheckResponse, error) {
@@ -183,16 +188,18 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	}
 
 	runnerID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	zitiServiceID := "service-id"
 	zitiServiceName := "runner-service"
 	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", zitiServiceID, zitiServiceName, runnerStatusPending, labelsJSON, capabilitiesJSON, now, now)
+		AddRow(runnerID, "runner-1", pgtype.UUID{Bytes: organizationID, Valid: true}, identityID, "", zitiServiceID, zitiServiceName, runnerStatusPending, labelsJSON, capabilitiesJSON, now, now)
 
 	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO runners (id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, service_token_hash, status, labels, capabilities)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n\t    RETURNING %s", runnerColumns))
 	mockPool.ExpectQuery(matcher).
-		WithArgs(pgxmock.AnyArg(), "runner-1", pgxmock.AnyArg(), pgxmock.AnyArg(), "", zitiServiceID, zitiServiceName, pgxmock.AnyArg(), runnerStatusPending, labelsJSON, capabilitiesJSON).
+		WithArgs(pgxmock.AnyArg(), "runner-1", pgtype.UUID{Bytes: organizationID, Valid: true}, pgxmock.AnyArg(), "", zitiServiceID, zitiServiceName, pgxmock.AnyArg(), runnerStatusPending, labelsJSON, capabilitiesJSON).
 		WillReturnRows(rows)
 
 	var gotIdentityReq *identityv1.RegisterIdentityRequest
@@ -202,8 +209,13 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 			return &identityv1.RegisterIdentityResponse{}, nil
 		},
 	}
+	var gotCheckReq *authorizationv1.CheckRequest
 	var gotWriteReq *authorizationv1.WriteRequest
 	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
 		write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
 			gotWriteReq = req
 			return &authorizationv1.WriteResponse{}, nil
@@ -227,10 +239,13 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 		ZitiManagementClient: zitiClient,
 	})
 
-	resp, err := srv.RegisterRunner(context.Background(), &runnersv1.RegisterRunnerRequest{
-		Name:         "runner-1",
-		Labels:       labels,
-		Capabilities: capabilities,
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	organizationValue := organizationID.String()
+	resp, err := srv.RegisterRunner(ctx, &runnersv1.RegisterRunnerRequest{
+		Name:           "runner-1",
+		OrganizationId: &organizationValue,
+		Labels:         labels,
+		Capabilities:   capabilities,
 	})
 	if err != nil {
 		t.Fatalf("RegisterRunner failed: %v", err)
@@ -253,8 +268,29 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	if gotIdentityReq == nil {
 		t.Fatal("expected RegisterIdentity to be called")
 	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
 	if gotWriteReq == nil {
 		t.Fatal("expected authorization Write to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected check user identity:%s, got %s", callerID, gotCheckReq.GetTupleKey().GetUser())
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != "owner" {
+		t.Fatalf("expected owner relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected organization:%s object, got %s", organizationID, gotCheckReq.GetTupleKey().GetObject())
+	}
+	if len(gotWriteReq.GetWrites()) != 1 {
+		t.Fatalf("expected one write tuple, got %d", len(gotWriteReq.GetWrites()))
+	}
+	if gotWriteReq.GetWrites()[0].GetRelation() != organizationMemberRelation {
+		t.Fatalf("expected member relation, got %s", gotWriteReq.GetWrites()[0].GetRelation())
+	}
+	if gotWriteReq.GetWrites()[0].GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected organization:%s write object, got %s", organizationID, gotWriteReq.GetWrites()[0].GetObject())
 	}
 	if gotServiceReq == nil {
 		t.Fatal("expected CreateService to be called")
@@ -271,6 +307,99 @@ func TestRegisterRunnerPersistsLabels(t *testing.T) {
 	}
 }
 
+func TestRegisterRunnerClusterScopedRequiresAdmin(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	labels := map[string]string{"tier": "gpu"}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatalf("failed to marshal labels: %v", err)
+	}
+	capabilities := []string{"gpu"}
+	capabilitiesJSON, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("failed to marshal capabilities: %v", err)
+	}
+
+	runnerID := uuid.New()
+	callerID := uuid.New()
+	identityID := uuid.New()
+	now := time.Now().UTC()
+	zitiServiceID := "service-id"
+	zitiServiceName := "runner-service"
+	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "", zitiServiceID, zitiServiceName, runnerStatusPending, labelsJSON, capabilitiesJSON, now, now)
+
+	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO runners (id, name, organization_id, identity_id, ziti_identity_id, ziti_service_id, ziti_service_name, service_token_hash, status, labels, capabilities)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n\t    RETURNING %s", runnerColumns))
+	mockPool.ExpectQuery(matcher).
+		WithArgs(pgxmock.AnyArg(), "runner-1", pgxmock.AnyArg(), pgxmock.AnyArg(), "", zitiServiceID, zitiServiceName, pgxmock.AnyArg(), runnerStatusPending, labelsJSON, capabilitiesJSON).
+		WillReturnRows(rows)
+
+	identityClient := fakeIdentityClient{
+		registerIdentity: func(ctx context.Context, req *identityv1.RegisterIdentityRequest) (*identityv1.RegisterIdentityResponse, error) {
+			return &identityv1.RegisterIdentityResponse{}, nil
+		},
+	}
+
+	var gotCheckReq *authorizationv1.CheckRequest
+	writeCalled := false
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+		write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+			writeCalled = true
+			return &authorizationv1.WriteResponse{}, nil
+		},
+	}
+
+	zitiClient := fakeZitiManagementClient{
+		createService: func(ctx context.Context, req *zitimanagementv1.CreateServiceRequest) (*zitimanagementv1.CreateServiceResponse, error) {
+			return &zitimanagementv1.CreateServiceResponse{
+				ZitiServiceId:   zitiServiceID,
+				ZitiServiceName: zitiServiceName,
+			}, nil
+		},
+	}
+
+	srv := New(Options{
+		Pool:                 mockPool,
+		IdentityClient:       identityClient,
+		AuthorizationClient:  authorizationClient,
+		ZitiManagementClient: zitiClient,
+	})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.RegisterRunner(ctx, &runnersv1.RegisterRunnerRequest{
+		Name:         "runner-1",
+		Labels:       labels,
+		Capabilities: capabilities,
+	})
+	if err != nil {
+		t.Fatalf("RegisterRunner failed: %v", err)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected admin relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %s, got %s", clusterObject, gotCheckReq.GetTupleKey().GetObject())
+	}
+	if writeCalled {
+		t.Fatal("did not expect authorization Write for cluster-scoped runner")
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
@@ -278,6 +407,8 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	}
 
 	runnerID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
 	identityID := uuid.New()
 	labels := map[string]string{"env": "prod", "type": "cpu"}
 	labelsJSON, err := json.Marshal(labels)
@@ -290,8 +421,13 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 		t.Fatalf("failed to marshal capabilities: %v", err)
 	}
 	now := time.Now().UTC()
-	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-updated", pgtype.UUID{Valid: false}, identityID, "", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
+	getRows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-updated", pgtype.UUID{Bytes: organizationID, Valid: true}, identityID, "", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
+	updateRows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
+		AddRow(runnerID, "runner-updated", pgtype.UUID{Bytes: organizationID, Valid: true}, identityID, "", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
+
+	getQuery := regexp.QuoteMeta(fmt.Sprintf(`SELECT %s FROM runners WHERE id = $1`, runnerColumns))
+	mockPool.ExpectQuery(getQuery).WithArgs(runnerID).WillReturnRows(getRows)
 
 	matcher := regexp.QuoteMeta(fmt.Sprintf(`UPDATE runners SET name = COALESCE($1, name), labels = COALESCE($2::jsonb, labels), capabilities = COALESCE($3::jsonb, capabilities), updated_at = NOW() WHERE id = $4 RETURNING %s`, runnerColumns))
 	mockPool.ExpectQuery(matcher).
@@ -301,11 +437,20 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 			pgtype.Text{String: string(capabilitiesJSON), Valid: true},
 			runnerID,
 		).
-		WillReturnRows(rows)
+		WillReturnRows(updateRows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	name := "runner-updated"
-	resp, err := srv.UpdateRunner(context.Background(), &runnersv1.UpdateRunnerRequest{
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.UpdateRunner(ctx, &runnersv1.UpdateRunnerRequest{
 		Id:           runnerID.String(),
 		Name:         &name,
 		Labels:       labels,
@@ -325,6 +470,12 @@ func TestUpdateRunnerUpdatesLabels(t *testing.T) {
 	}
 	if !slices.Equal(resp.GetRunner().GetCapabilities(), capabilities) {
 		t.Fatalf("expected capabilities %v, got %v", capabilities, resp.GetRunner().GetCapabilities())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != "owner" {
+		t.Fatalf("expected owner relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -483,6 +634,8 @@ func TestDeleteRunnerCallsZitiCleanup(t *testing.T) {
 	deleteQuery := regexp.QuoteMeta(`DELETE FROM runners WHERE id = $1`)
 
 	runnerID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	labelsJSON := []byte("{}")
@@ -491,7 +644,7 @@ func TestDeleteRunnerCallsZitiCleanup(t *testing.T) {
 	zitiServiceName := "runner-service"
 	zitiIdentityID := "ziti-identity"
 	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, zitiIdentityID, zitiServiceID, zitiServiceName, runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
+		AddRow(runnerID, "runner-1", pgtype.UUID{Bytes: organizationID, Valid: true}, identityID, zitiIdentityID, zitiServiceID, zitiServiceName, runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
 
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(runnerID).WillReturnRows(rows)
 	mockPool.ExpectExec(deleteQuery).WithArgs(runnerID).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -504,7 +657,12 @@ func TestDeleteRunnerCallsZitiCleanup(t *testing.T) {
 		},
 	}
 
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
 		write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
 			return &authorizationv1.WriteResponse{}, nil
 		},
@@ -516,7 +674,8 @@ func TestDeleteRunnerCallsZitiCleanup(t *testing.T) {
 		ZitiManagementClient: zitiClient,
 	})
 
-	_, err = srv.DeleteRunner(context.Background(), &runnersv1.DeleteRunnerRequest{Id: runnerID.String()})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.DeleteRunner(ctx, &runnersv1.DeleteRunnerRequest{Id: runnerID.String()})
 	if err != nil {
 		t.Fatalf("DeleteRunner failed: %v", err)
 	}
@@ -529,6 +688,9 @@ func TestDeleteRunnerCallsZitiCleanup(t *testing.T) {
 	}
 	if gotDeleteReq.GetZitiServiceId() != zitiServiceID {
 		t.Fatalf("expected ziti service id %q, got %q", zitiServiceID, gotDeleteReq.GetZitiServiceId())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -546,12 +708,14 @@ func TestDeleteRunnerBestEffortZitiFailure(t *testing.T) {
 	deleteQuery := regexp.QuoteMeta(`DELETE FROM runners WHERE id = $1`)
 
 	runnerID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
 	identityID := uuid.New()
 	now := time.Now().UTC()
 	labelsJSON := []byte("{}")
 	capabilitiesJSON := []byte("[]")
 	rows := pgxmock.NewRows([]string{"id", "name", "organization_id", "identity_id", "ziti_identity_id", "ziti_service_id", "ziti_service_name", "status", "labels", "capabilities", "created_at", "updated_at"}).
-		AddRow(runnerID, "runner-1", pgtype.UUID{Valid: false}, identityID, "ziti-identity", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
+		AddRow(runnerID, "runner-1", pgtype.UUID{Bytes: organizationID, Valid: true}, identityID, "ziti-identity", "service-id", "runner-service", runnerStatusOffline, labelsJSON, capabilitiesJSON, now, now)
 
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(runnerID).WillReturnRows(rows)
 	mockPool.ExpectExec(deleteQuery).WithArgs(runnerID).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -564,7 +728,12 @@ func TestDeleteRunnerBestEffortZitiFailure(t *testing.T) {
 		},
 	}
 
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
 		write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
 			return &authorizationv1.WriteResponse{}, nil
 		},
@@ -576,12 +745,16 @@ func TestDeleteRunnerBestEffortZitiFailure(t *testing.T) {
 		ZitiManagementClient: zitiClient,
 	})
 
-	_, err = srv.DeleteRunner(context.Background(), &runnersv1.DeleteRunnerRequest{Id: runnerID.String()})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.DeleteRunner(ctx, &runnersv1.DeleteRunnerRequest{Id: runnerID.String()})
 	if err != nil {
 		t.Fatalf("DeleteRunner failed: %v", err)
 	}
 	if gotDeleteReq == nil {
 		t.Fatal("expected DeleteRunnerIdentity to be called")
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,10 +20,12 @@ const (
 	maxListPageSize     int32 = 100
 
 	clusterObject              = "cluster:global"
-	clusterWriterRelation      = "writer"
+	clusterAdminRelation       = "admin"
 	organizationMemberRelation = "member"
+	organizationOwnerRelation  = "owner"
 	identityObjectPrefix       = "identity:"
 	organizationObjectPrefix   = "organization:"
+	identityMetadata           = "x-identity-id"
 )
 
 // Server implements the RunnersService gRPC API.

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -179,6 +179,10 @@ func (s *Server) UpdateVolume(ctx context.Context, req *runnersv1.UpdateVolumeRe
 }
 
 func (s *Server) GetVolume(ctx context.Context, req *runnersv1.GetVolumeRequest) (*runnersv1.GetVolumeResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -186,6 +190,9 @@ func (s *Server) GetVolume(ctx context.Context, req *runnersv1.GetVolumeRequest)
 	volume, err := s.getVolumeByID(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgMember(ctx, callerID, volume.OrganizationID); err != nil {
+		return nil, err
 	}
 	protoVolume, err := toProtoVolume(volume)
 	if err != nil {
@@ -195,6 +202,10 @@ func (s *Server) GetVolume(ctx context.Context, req *runnersv1.GetVolumeRequest)
 }
 
 func (s *Server) ListVolumesByThread(ctx context.Context, req *runnersv1.ListVolumesByThreadRequest) (*runnersv1.ListVolumesByThreadResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	threadID, err := parseUUID(req.GetThreadId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
@@ -207,7 +218,18 @@ func (s *Server) ListVolumesByThread(ctx context.Context, req *runnersv1.ListVol
 		}
 		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
 	}
-	protoVolumes, err := toProtoVolumeList(volumes)
+	memberCache := map[uuid.UUID]bool{}
+	filtered := make([]volumeRecord, 0, len(volumes))
+	for _, volume := range volumes {
+		allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			filtered = append(filtered, volume)
+		}
+	}
+	protoVolumes, err := toProtoVolumeList(filtered)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert volumes: %v", err)
 	}
@@ -215,6 +237,10 @@ func (s *Server) ListVolumesByThread(ctx context.Context, req *runnersv1.ListVol
 }
 
 func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequest) (*runnersv1.ListVolumesResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	statuses, err := volumeStatusesToStrings(req.GetStatuses())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
@@ -226,6 +252,11 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
 		organizationID = &parsed
+	}
+	if organizationID != nil {
+		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
+			return nil, err
+		}
 	}
 
 	var runnerID *uuid.UUID
@@ -246,6 +277,20 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", invalidToken.Err)
 		}
 		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
+	}
+	if organizationID == nil {
+		memberCache := map[uuid.UUID]bool{}
+		filtered := make([]volumeRecord, 0, len(volumes))
+		for _, volume := range volumes {
+			allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
+			if err != nil {
+				return nil, err
+			}
+			if allowed {
+				filtered = append(filtered, volume)
+			}
+		}
+		volumes = filtered
 	}
 	protoVolumes, err := toProtoVolumeList(volumes)
 	if err != nil {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -223,6 +223,73 @@ func TestListVolumesInvalidUUID(t *testing.T) {
 	}
 }
 
+func TestListVolumesRequiresMember(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	organizationID := uuid.New()
+	callerID := uuid.New()
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetVolumeRequiresMember(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE id = $1", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(volumeID).WillReturnRows(rows)
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.GetVolume(ctx, &runnersv1.GetVolumeRequest{Id: volumeID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestUpdateVolume(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v3"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -43,6 +45,7 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	runnerID := uuid.New()
 	agentID := uuid.New()
 	organizationID := uuid.New()
+	callerID := uuid.New()
 	now := time.Now().UTC()
 
 	rows := pgxmock.NewRows(volumeRowColumns).
@@ -53,9 +56,18 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	organizationIDValue := organizationID.String()
-	resp, err := srv.ListVolumes(context.Background(), &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
@@ -64,6 +76,9 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	}
 	if resp.GetVolumes()[0].GetOrganizationId() != organizationID.String() {
 		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetVolumes()[0].GetOrganizationId())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -83,6 +98,7 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	runnerID := uuid.New()
 	agentID := uuid.New()
 	organizationID := uuid.New()
+	callerID := uuid.New()
 	now := time.Now().UTC()
 
 	rows := pgxmock.NewRows(volumeRowColumns).
@@ -93,9 +109,18 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 		WithArgs(runnerID, 51).
 		WillReturnRows(rows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	runnerIDValue := runnerID.String()
-	resp, err := srv.ListVolumes(context.Background(), &runnersv1.ListVolumesRequest{RunnerId: &runnerIDValue})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{RunnerId: &runnerIDValue})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
@@ -104,6 +129,9 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	}
 	if resp.GetVolumes()[0].GetRunnerId() != runnerID.String() {
 		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetVolumes()[0].GetRunnerId())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -123,6 +151,7 @@ func TestListVolumesPendingSample(t *testing.T) {
 	runnerID := uuid.New()
 	agentID := uuid.New()
 	organizationID := uuid.New()
+	callerID := uuid.New()
 	now := time.Now().UTC()
 
 	rows := pgxmock.NewRows(volumeRowColumns).
@@ -133,14 +162,26 @@ func TestListVolumesPendingSample(t *testing.T) {
 		WithArgs(51).
 		WillReturnRows(rows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	pendingSample := true
-	resp, err := srv.ListVolumes(context.Background(), &runnersv1.ListVolumesRequest{PendingSample: &pendingSample})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{PendingSample: &pendingSample})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
 	if len(resp.GetVolumes()) != 1 {
 		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -150,6 +191,7 @@ func TestListVolumesPendingSample(t *testing.T) {
 
 func TestListVolumesInvalidUUID(t *testing.T) {
 	srv := New(Options{})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, uuid.NewString()))
 
 	cases := []struct {
 		name string
@@ -173,7 +215,7 @@ func TestListVolumesInvalidUUID(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := srv.ListVolumes(context.Background(), testCase.req)
+			_, err := srv.ListVolumes(ctx, testCase.req)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("expected InvalidArgument error, got %v", err)
 			}

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -260,14 +260,7 @@ func (s *Server) TouchWorkload(ctx context.Context, req *runnersv1.TouchWorkload
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	workload, err := s.getWorkloadByID(ctx, id)
-	if err != nil {
-		return nil, toStatusError(err)
-	}
-	if workload.AgentID != callerID {
-		return nil, status.Error(codes.PermissionDenied, "permission denied")
-	}
-	if err := s.touchWorkload(ctx, id); err != nil {
+	if err := s.touchWorkloadForAgent(ctx, id, callerID); err != nil {
 		return nil, toStatusError(err)
 	}
 	return &runnersv1.TouchWorkloadResponse{}, nil
@@ -524,13 +517,17 @@ func (s *Server) softDeleteWorkload(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (s *Server) touchWorkload(ctx context.Context, id uuid.UUID) error {
-	result, err := s.pool.Exec(ctx, `UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1`, id)
+func (s *Server) touchWorkloadForAgent(ctx context.Context, id uuid.UUID, agentID uuid.UUID) error {
+	result, err := s.pool.Exec(ctx, `UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1 AND agent_id = $2`, id, agentID)
 	if err != nil {
 		return err
 	}
 	if result.RowsAffected() == 0 {
-		return NotFound("workload")
+		_, err := s.getWorkloadByID(ctx, id)
+		if err != nil {
+			return err
+		}
+		return PermissionDenied()
 	}
 	return nil
 }

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -252,9 +252,20 @@ func (s *Server) UpdateWorkloadStatus(ctx context.Context, req *runnersv1.Update
 }
 
 func (s *Server) TouchWorkload(ctx context.Context, req *runnersv1.TouchWorkloadRequest) (*runnersv1.TouchWorkloadResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	workload, err := s.getWorkloadByID(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if workload.AgentID != callerID {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
 	}
 	if err := s.touchWorkload(ctx, id); err != nil {
 		return nil, toStatusError(err)
@@ -274,6 +285,10 @@ func (s *Server) DeleteWorkload(ctx context.Context, req *runnersv1.DeleteWorklo
 }
 
 func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequest) (*runnersv1.GetWorkloadResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -281,6 +296,9 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	workload, err := s.getWorkloadByID(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgMember(ctx, callerID, workload.OrganizationID); err != nil {
+		return nil, err
 	}
 	protoWorkload, err := toProtoWorkload(workload)
 	if err != nil {
@@ -290,6 +308,10 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 }
 
 func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListWorkloadsByThreadRequest) (*runnersv1.ListWorkloadsByThreadResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	threadID, err := parseUUID(req.GetThreadId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
@@ -302,7 +324,18 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 		}
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
 	}
-	protoWorkloads, err := toProtoWorkloadList(workloads)
+	memberCache := map[uuid.UUID]bool{}
+	filtered := make([]workloadRecord, 0, len(workloads))
+	for _, workload := range workloads {
+		allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			filtered = append(filtered, workload)
+		}
+	}
+	protoWorkloads, err := toProtoWorkloadList(filtered)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert workloads: %v", err)
 	}
@@ -310,6 +343,10 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 }
 
 func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloadsRequest) (*runnersv1.ListWorkloadsResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	statuses, err := workloadStatusesToStrings(req.GetStatuses())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
@@ -321,6 +358,11 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
 		organizationID = &parsed
+	}
+	if organizationID != nil {
+		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
+			return nil, err
+		}
 	}
 
 	var runnerID *uuid.UUID
@@ -341,6 +383,20 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", invalidToken.Err)
 		}
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
+	}
+	if organizationID == nil {
+		memberCache := map[uuid.UUID]bool{}
+		filtered := make([]workloadRecord, 0, len(workloads))
+		for _, workload := range workloads {
+			allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
+			if err != nil {
+				return nil, err
+			}
+			if allowed {
+				filtered = append(filtered, workload)
+			}
+		}
+		workloads = filtered
 	}
 	protoWorkloads, err := toProtoWorkloadList(workloads)
 	if err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 	"time"
 
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v3"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -46,6 +48,7 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	threadID := uuid.New()
 	agentID := uuid.New()
 	organizationID := uuid.New()
+	callerID := uuid.New()
 	now := time.Now().UTC()
 	containersJSON := []byte("[]")
 
@@ -57,9 +60,18 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	organizationIDValue := organizationID.String()
-	resp, err := srv.ListWorkloads(context.Background(), &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
@@ -68,6 +80,12 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	}
 	if resp.GetWorkloads()[0].GetOrganizationId() != organizationID.String() {
 		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetWorkloads()[0].GetOrganizationId())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationMemberRelation {
+		t.Fatalf("expected member relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -86,6 +104,7 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	threadID := uuid.New()
 	agentID := uuid.New()
 	organizationID := uuid.New()
+	callerID := uuid.New()
 	now := time.Now().UTC()
 	containersJSON := []byte("[]")
 
@@ -97,9 +116,18 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 		WithArgs(runnerID, 51).
 		WillReturnRows(rows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	runnerIDValue := runnerID.String()
-	resp, err := srv.ListWorkloads(context.Background(), &runnersv1.ListWorkloadsRequest{RunnerId: &runnerIDValue})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{RunnerId: &runnerIDValue})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
@@ -108,6 +136,9 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	}
 	if resp.GetWorkloads()[0].GetRunnerId() != runnerID.String() {
 		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetWorkloads()[0].GetRunnerId())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -126,6 +157,7 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	threadID := uuid.New()
 	agentID := uuid.New()
 	organizationID := uuid.New()
+	callerID := uuid.New()
 	now := time.Now().UTC()
 	containersJSON := []byte("[]")
 
@@ -137,14 +169,26 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 		WithArgs(51).
 		WillReturnRows(rows)
 
-	srv := New(Options{Pool: mockPool})
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	pendingSample := true
-	resp, err := srv.ListWorkloads(context.Background(), &runnersv1.ListWorkloadsRequest{PendingSample: &pendingSample})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{PendingSample: &pendingSample})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
 	if len(resp.GetWorkloads()) != 1 {
 		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -154,6 +198,7 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 
 func TestListWorkloadsInvalidUUID(t *testing.T) {
 	srv := New(Options{})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, uuid.NewString()))
 
 	cases := []struct {
 		name string
@@ -177,7 +222,7 @@ func TestListWorkloadsInvalidUUID(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := srv.ListWorkloads(context.Background(), testCase.req)
+			_, err := srv.ListWorkloads(ctx, testCase.req)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("expected InvalidArgument error, got %v", err)
 			}
@@ -192,15 +237,61 @@ func TestTouchWorkload(t *testing.T) {
 	}
 
 	workloadID := uuid.New()
+	agentID := uuid.New()
+	callerID := agentID
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	getQuery := fmt.Sprintf(`SELECT %s FROM workloads WHERE id = $1`, workloadColumns)
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(getQuery)).WithArgs(workloadID).WillReturnRows(rows)
+
 	query := "UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1"
 	mockPool.ExpectExec(regexp.QuoteMeta(query)).
 		WithArgs(workloadID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	srv := New(Options{Pool: mockPool})
-	_, err = srv.TouchWorkload(context.Background(), &runnersv1.TouchWorkloadRequest{Id: workloadID.String()})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID.String()})
 	if err != nil {
 		t.Fatalf("TouchWorkload failed: %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestTouchWorkloadRequiresAgentIdentity(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	agentID := uuid.New()
+	callerID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	getQuery := fmt.Sprintf(`SELECT %s FROM workloads WHERE id = $1`, workloadColumns)
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(getQuery)).WithArgs(workloadID).WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -230,6 +230,73 @@ func TestListWorkloadsInvalidUUID(t *testing.T) {
 	}
 }
 
+func TestListWorkloadsRequiresMember(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	organizationID := uuid.New()
+	callerID := uuid.New()
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetWorkloadRequiresMember(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestTouchWorkload(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
@@ -239,20 +306,10 @@ func TestTouchWorkload(t *testing.T) {
 	workloadID := uuid.New()
 	agentID := uuid.New()
 	callerID := agentID
-	runnerID := uuid.New()
-	threadID := uuid.New()
-	organizationID := uuid.New()
-	now := time.Now().UTC()
-	containersJSON := []byte("[]")
 
-	getQuery := fmt.Sprintf(`SELECT %s FROM workloads WHERE id = $1`, workloadColumns)
-	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
-	mockPool.ExpectQuery(regexp.QuoteMeta(getQuery)).WithArgs(workloadID).WillReturnRows(rows)
-
-	query := "UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1"
+	query := "UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1 AND agent_id = $2"
 	mockPool.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(workloadID).
+		WithArgs(workloadID, callerID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	srv := New(Options{Pool: mockPool})
@@ -281,6 +338,11 @@ func TestTouchWorkloadRequiresAgentIdentity(t *testing.T) {
 	organizationID := uuid.New()
 	now := time.Now().UTC()
 	containersJSON := []byte("[]")
+
+	query := "UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1 AND agent_id = $2"
+	mockPool.ExpectExec(regexp.QuoteMeta(query)).
+		WithArgs(workloadID, callerID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 	getQuery := fmt.Sprintf(`SELECT %s FROM workloads WHERE id = $1`, workloadColumns)
 	rows := pgxmock.NewRows(workloadRowColumns).

--- a/test/e2e/authz_helpers_test.go
+++ b/test/e2e/authz_helpers_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
+)
+
+const (
+	authorizationIdentityPrefix     = "identity:"
+	authorizationOrganizationPrefix = "organization:"
+	authorizationMemberRelation     = "member"
+)
+
+func ensureOrganizationMember(t *testing.T, ctx context.Context, identityID string, organizationID string) {
+	t.Helper()
+	if authzClient == nil {
+		t.Fatal("authorization client not initialized")
+	}
+	tuple := &authorizationv1.TupleKey{
+		User:     authorizationIdentityPrefix + identityID,
+		Relation: authorizationMemberRelation,
+		Object:   authorizationOrganizationPrefix + organizationID,
+	}
+	if _, err := authzClient.Write(ctx, &authorizationv1.WriteRequest{Writes: []*authorizationv1.TupleKey{tuple}}); err != nil {
+		t.Fatalf("authorization write failed: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cleanupCancel()
+		_, _ = authzClient.Write(cleanupCtx, &authorizationv1.WriteRequest{Deletes: []*authorizationv1.TupleKey{tuple}})
+	})
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -10,19 +10,29 @@ import (
 	"testing"
 	"time"
 
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
-	defaultRunnersAddress = "runners:50051"
-	dialTimeout           = 20 * time.Second
+	defaultRunnersAddress       = "runners:50051"
+	defaultAuthorizationAddress = "authorization:50051"
+	dialTimeout                 = 20 * time.Second
+	identityMetadataKey         = "x-identity-id"
+	identityTypeMetadataKey     = "x-identity-type"
+	identityTypeUser            = "user"
+	identityTypeAgent           = "agent"
+	clusterAdminIdentityID      = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
 )
 
 var (
 	runnerClient runnersv1.RunnersServiceClient
 	runnerConn   *grpc.ClientConn
+	authzClient  authorizationv1.AuthorizationServiceClient
+	authzConn    *grpc.ClientConn
 )
 
 func envOrDefault(key, fallback string) string {
@@ -39,6 +49,7 @@ func envOrDefault(key, fallback string) string {
 
 func TestMain(m *testing.M) {
 	addr := envOrDefault("RUNNERS_ADDRESS", defaultRunnersAddress)
+	authorizationAddr := envOrDefault("AUTHORIZATION_ADDRESS", defaultAuthorizationAddress)
 
 	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 	defer cancel()
@@ -52,9 +63,36 @@ func TestMain(m *testing.M) {
 	runnerConn = conn
 	runnerClient = runnersv1.NewRunnersServiceClient(conn)
 
+	authorizationConn, err := grpc.DialContext(ctx, authorizationAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to connect to %s: %v\n", authorizationAddr, err)
+		_ = conn.Close()
+		os.Exit(1)
+	}
+	authzConn = authorizationConn
+	authzClient = authorizationv1.NewAuthorizationServiceClient(authorizationConn)
+
 	exitCode := m.Run()
 	if err := conn.Close(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to close gRPC connection: %v\n", err)
 	}
+	if err := authorizationConn.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close authorization connection: %v\n", err)
+	}
 	os.Exit(exitCode)
+}
+
+func contextWithIdentity(ctx context.Context, identityID string, identityType string) context.Context {
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		identityMetadataKey, identityID,
+		identityTypeMetadataKey, identityType,
+	))
+}
+
+func adminContext(ctx context.Context) context.Context {
+	return contextWithIdentity(ctx, clusterAdminIdentityID, identityTypeUser)
+}
+
+func agentContext(ctx context.Context, agentID string) context.Context {
+	return contextWithIdentity(ctx, agentID, identityTypeAgent)
 }

--- a/test/e2e/runners_test.go
+++ b/test/e2e/runners_test.go
@@ -17,12 +17,13 @@ const testTimeout = 60 * time.Second
 func TestRunnerLifecycle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
+	adminCtx := adminContext(ctx)
 
 	registerLabels := map[string]string{
 		"region": "test",
 		"tier":   "e2e",
 	}
-	registerResp, err := runnerClient.RegisterRunner(ctx, &runnersv1.RegisterRunnerRequest{
+	registerResp, err := runnerClient.RegisterRunner(adminCtx, &runnersv1.RegisterRunnerRequest{
 		Name:   "e2e-runner",
 		Labels: registerLabels,
 	})
@@ -49,10 +50,11 @@ func TestRunnerLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
 		_, _ = runnerClient.DeleteRunner(cleanupCtx, &runnersv1.DeleteRunnerRequest{Id: runnerID})
 	})
 
-	validateResp, err := runnerClient.ValidateServiceToken(ctx, &runnersv1.ValidateServiceTokenRequest{
+	validateResp, err := runnerClient.ValidateServiceToken(adminCtx, &runnersv1.ValidateServiceTokenRequest{
 		TokenHash: token,
 	})
 	if err != nil {
@@ -66,8 +68,9 @@ func TestRunnerLifecycle(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, adminCtx, clusterAdminIdentityID, organizationID)
 
-	createResp, err := runnerClient.CreateWorkload(ctx, &runnersv1.CreateWorkloadRequest{
+	createResp, err := runnerClient.CreateWorkload(adminCtx, &runnersv1.CreateWorkloadRequest{
 		Id:             workloadID,
 		RunnerId:       runnerID,
 		ThreadId:       threadID,
@@ -92,6 +95,7 @@ func TestRunnerLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
 		_, _ = runnerClient.DeleteWorkload(cleanupCtx, &runnersv1.DeleteWorkloadRequest{Id: workloadID})
 	})
 
@@ -99,7 +103,7 @@ func TestRunnerLifecycle(t *testing.T) {
 		t.Fatalf("CreateWorkload returned unexpected ID")
 	}
 
-	updateResp, err := runnerClient.UpdateWorkloadStatus(ctx, &runnersv1.UpdateWorkloadStatusRequest{
+	updateResp, err := runnerClient.UpdateWorkloadStatus(adminCtx, &runnersv1.UpdateWorkloadStatusRequest{
 		Id:     workloadID,
 		Status: runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
 		Containers: []*runnersv1.Container{
@@ -119,11 +123,12 @@ func TestRunnerLifecycle(t *testing.T) {
 		t.Fatalf("UpdateWorkloadStatus did not return running status")
 	}
 
-	if _, err := runnerClient.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID}); err != nil {
+	agentCtx := agentContext(ctx, agentID)
+	if _, err := runnerClient.TouchWorkload(agentCtx, &runnersv1.TouchWorkloadRequest{Id: workloadID}); err != nil {
 		t.Fatalf("TouchWorkload failed: %v", err)
 	}
 
-	getResp, err := runnerClient.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID})
+	getResp, err := runnerClient.GetWorkload(adminCtx, &runnersv1.GetWorkloadRequest{Id: workloadID})
 	if err != nil {
 		t.Fatalf("GetWorkload failed: %v", err)
 	}
@@ -131,7 +136,7 @@ func TestRunnerLifecycle(t *testing.T) {
 		t.Fatalf("GetWorkload returned unexpected thread ID")
 	}
 
-	listByThreadResp, err := runnerClient.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{
+	listByThreadResp, err := runnerClient.ListWorkloadsByThread(adminCtx, &runnersv1.ListWorkloadsByThreadRequest{
 		ThreadId:  threadID,
 		PageSize:  10,
 		PageToken: "",
@@ -143,7 +148,7 @@ func TestRunnerLifecycle(t *testing.T) {
 		t.Fatalf("ListWorkloadsByThread missing workload")
 	}
 
-	listResp, err := runnerClient.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{
+	listResp, err := runnerClient.ListWorkloads(adminCtx, &runnersv1.ListWorkloadsRequest{
 		PageSize: 10,
 		Statuses: []runnersv1.WorkloadStatus{runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING},
 	})
@@ -154,11 +159,11 @@ func TestRunnerLifecycle(t *testing.T) {
 		t.Fatalf("ListWorkloads missing workload")
 	}
 
-	if _, err := runnerClient.DeleteWorkload(ctx, &runnersv1.DeleteWorkloadRequest{Id: workloadID}); err != nil {
+	if _, err := runnerClient.DeleteWorkload(adminCtx, &runnersv1.DeleteWorkloadRequest{Id: workloadID}); err != nil {
 		t.Fatalf("DeleteWorkload failed: %v", err)
 	}
 
-	deletedResp, err := runnerClient.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID})
+	deletedResp, err := runnerClient.GetWorkload(adminCtx, &runnersv1.GetWorkloadRequest{Id: workloadID})
 	if err != nil {
 		t.Fatalf("GetWorkload after delete failed: %v", err)
 	}
@@ -169,7 +174,7 @@ func TestRunnerLifecycle(t *testing.T) {
 		t.Fatalf("expected removed_at after delete")
 	}
 
-	if _, err := runnerClient.DeleteRunner(ctx, &runnersv1.DeleteRunnerRequest{Id: runnerID}); err != nil {
+	if _, err := runnerClient.DeleteRunner(adminCtx, &runnersv1.DeleteRunnerRequest{Id: runnerID}); err != nil {
 		t.Fatalf("DeleteRunner failed: %v", err)
 	}
 }

--- a/test/e2e/sampled_at_test.go
+++ b/test/e2e/sampled_at_test.go
@@ -18,6 +18,7 @@ func TestBatchUpdateWorkloadSampledAtSingle(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, clusterAdminIdentityID, organizationID)
 
 	workloadID := uuid.NewString()
 	createWorkload(t, ctx, workloadID, runnerID, threadID, agentID, organizationID)
@@ -42,6 +43,7 @@ func TestBatchUpdateWorkloadSampledAtMultiple(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, clusterAdminIdentityID, organizationID)
 
 	workloadIDs := []string{uuid.NewString(), uuid.NewString()}
 	for _, workloadID := range workloadIDs {
@@ -77,6 +79,7 @@ func TestBatchUpdateWorkloadSampledAtIdempotent(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, clusterAdminIdentityID, organizationID)
 
 	workloadID := uuid.NewString()
 	createWorkload(t, ctx, workloadID, runnerID, threadID, agentID, organizationID)
@@ -106,6 +109,7 @@ func TestBatchUpdateVolumeSampledAtSingle(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, clusterAdminIdentityID, organizationID)
 
 	volumeID := uuid.NewString()
 	volumeExternalID := uuid.NewString()
@@ -131,6 +135,7 @@ func TestBatchUpdateVolumeSampledAtMultiple(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, clusterAdminIdentityID, organizationID)
 
 	volumeIDs := []string{uuid.NewString(), uuid.NewString()}
 	volumeExternalIDs := []string{uuid.NewString(), uuid.NewString()}
@@ -167,6 +172,7 @@ func TestBatchUpdateVolumeSampledAtIdempotent(t *testing.T) {
 	threadID := uuid.NewString()
 	agentID := uuid.NewString()
 	organizationID := uuid.NewString()
+	ensureOrganizationMember(t, ctx, clusterAdminIdentityID, organizationID)
 
 	volumeID := uuid.NewString()
 	volumeExternalID := uuid.NewString()
@@ -203,7 +209,7 @@ func newTestContext(t *testing.T) context.Context {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	t.Cleanup(cancel)
-	return ctx
+	return adminContext(ctx)
 }
 
 func cleanupRunner(t *testing.T, runnerID string) {
@@ -211,6 +217,7 @@ func cleanupRunner(t *testing.T, runnerID string) {
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
 		_, _ = runnerClient.DeleteRunner(cleanupCtx, &runnersv1.DeleteRunnerRequest{Id: runnerID})
 	})
 }
@@ -220,6 +227,7 @@ func cleanupWorkload(t *testing.T, workloadID string) {
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
 		_, _ = runnerClient.DeleteWorkload(cleanupCtx, &runnersv1.DeleteWorkloadRequest{Id: workloadID})
 	})
 }
@@ -229,6 +237,7 @@ func cleanupVolume(t *testing.T, volumeID string) {
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cleanupCancel()
+		cleanupCtx = adminContext(cleanupCtx)
 		_, _ = runnerClient.UpdateVolume(cleanupCtx, &runnersv1.UpdateVolumeRequest{
 			Id:        volumeID,
 			Status:    runnersv1.VolumeStatus_VOLUME_STATUS_DELETED.Enum(),


### PR DESCRIPTION
## Summary
- add authorization helpers and metadata parsing for runner APIs
- enforce runner/workload/volume access checks plus TouchWorkload identity guard
- drop cluster writer tuples and update auth-focused tests

## Testing
- go vet ./...
- go test ./...

Refs #136