### PR TITLE
feat(workloads): add failure metadata

### DIFF
--- a/internal/server/workload_logs_test.go
+++ b/internal/server/workload_logs_test.go
@@ -131,7 +131,7 @@ func TestStreamWorkloadLogsProxiesRunnerStream(t *testing.T) {
 	}
 
 	workloadRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
 	workloadQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(workloadQuery)).
 		WithArgs(workloadID).
@@ -238,7 +238,7 @@ func TestStreamWorkloadLogsRequiresMember(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	workloadRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), "instance-1", now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), "instance-1", now, nil, nil, now, now)
 	workloadQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(workloadQuery)).
 		WithArgs(workloadID).
@@ -287,7 +287,7 @@ func TestStreamWorkloadLogsMissingInstanceID(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	workloadRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 	workloadQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(workloadQuery)).
 		WithArgs(workloadID).

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -238,7 +238,7 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 	}
 
 	var existingWorkload *workloadRecord
-	if s.notificationsClient != nil && (statusValue != nil || containersJSON != nil) {
+	if s.notificationsClient != nil && (statusValue != nil || containersJSON != nil || failureReason != nil || failureMessage != nil) {
 		workload, err := s.getWorkloadByID(ctx, id)
 		if err != nil {
 			return nil, toStatusError(err)
@@ -261,8 +261,10 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 	}
 	statusChanged := existingWorkload != nil && statusValue != nil && *statusValue != existingWorkload.Status
 	containersChanged := existingWorkload != nil && containersJSON != nil && !containersEqualByName(existingWorkload.Containers, containerRecords)
-	if statusChanged || containersChanged {
-		s.publishWorkloadUpdateNotifications(ctx, workload, statusChanged, containersChanged)
+	failureReasonChanged := existingWorkload != nil && failureReason != nil && (existingWorkload.FailureReason == nil || *existingWorkload.FailureReason != *failureReason)
+	failureMessageChanged := existingWorkload != nil && failureMessage != nil && (existingWorkload.FailureMessage == nil || *existingWorkload.FailureMessage != *failureMessage)
+	if statusChanged || containersChanged || failureReasonChanged || failureMessageChanged {
+		s.publishWorkloadUpdateNotifications(ctx, workload, statusChanged, containersChanged, failureReasonChanged || failureMessageChanged)
 	}
 	protoWorkload, err := toProtoWorkload(workload)
 	if err != nil {
@@ -271,14 +273,21 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 	return &runnersv1.UpdateWorkloadResponse{Workload: protoWorkload}, nil
 }
 
-func (s *Server) publishWorkloadUpdateNotifications(ctx context.Context, workload workloadRecord, statusChanged, containersChanged bool) {
+func (s *Server) publishWorkloadUpdateNotifications(ctx context.Context, workload workloadRecord, statusChanged, containersChanged, failureChanged bool) {
 	if s.notificationsClient == nil {
 		return
 	}
-	payload, err := structpb.NewStruct(map[string]any{
+	payloadFields := map[string]any{
 		"workload_id": workload.Meta.ID.String(),
 		"status":      workload.Status,
-	})
+	}
+	if workload.FailureReason != nil {
+		payloadFields["failure_reason"] = *workload.FailureReason
+	}
+	if workload.FailureMessage != nil {
+		payloadFields["failure_message"] = *workload.FailureMessage
+	}
+	payload, err := structpb.NewStruct(payloadFields)
 	if err != nil {
 		log.Printf("runners: build workload notification payload: %v", err)
 		return
@@ -288,7 +297,7 @@ func (s *Server) publishWorkloadUpdateNotifications(ctx context.Context, workloa
 		fmt.Sprintf("organization:%s", workload.OrganizationID.String()),
 		workloadRoom,
 	}
-	if statusChanged || containersChanged {
+	if statusChanged || containersChanged || failureChanged {
 		s.publishWorkloadNotification(ctx, "workload.updated", updatedRooms, payload)
 	}
 	if statusChanged {

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -419,9 +419,9 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 		}
 		agentID = &parsed
 	}
-	statuses, err := workloadStatusesToStrings(req.GetStatusIn())
+	statuses, err := workloadStatusesToStrings(req.GetStatuses())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "status_in: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
 	}
 	workloads, nextToken, err := s.listWorkloadsByThread(ctx, threadID, agentID, statuses, req.GetPageSize(), req.GetPageToken())
 	if err != nil {

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,12 @@ const (
 	workloadStatusStopped  = "stopped"
 	workloadStatusFailed   = "failed"
 
+	workloadFailureReasonStartFailed     = "start_failed"
+	workloadFailureReasonImagePullFailed = "image_pull_failed"
+	workloadFailureReasonConfigInvalid   = "config_invalid"
+	workloadFailureReasonCrashloop       = "crashloop"
+	workloadFailureReasonRuntimeLost     = "runtime_lost"
+
 	containerRoleMain    = "main"
 	containerRoleSidecar = "sidecar"
 	containerRoleInit    = "init"
@@ -36,7 +43,7 @@ const (
 	containerStatusTerminated = "terminated"
 	containerStatusWaiting    = "waiting"
 
-	workloadColumns = `id, runner_id, thread_id, agent_id, organization_id, status, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, instance_id, last_activity_at, last_metering_sampled_at, removed_at, created_at, updated_at`
+	workloadColumns = `id, runner_id, thread_id, agent_id, organization_id, status, failure_reason, failure_message, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, instance_id, last_activity_at, last_metering_sampled_at, removed_at, created_at, updated_at`
 )
 
 type workloadRecord struct {
@@ -46,6 +53,8 @@ type workloadRecord struct {
 	AgentID                uuid.UUID
 	OrganizationID         uuid.UUID
 	Status                 string
+	FailureReason          *string
+	FailureMessage         *string
 	Containers             []containerRecord
 	ZitiIdentityID         string
 	AllocatedCPUMillicores int32
@@ -72,6 +81,8 @@ type workloadInsertInput struct {
 type workloadUpdateInput struct {
 	ID             uuid.UUID
 	Status         *string
+	FailureReason  *string
+	FailureMessage *string
 	ContainersJSON *[]byte
 	InstanceID     *string
 	RemovedAt      *time.Time
@@ -165,6 +176,21 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 		statusValue = &value
 	}
 
+	var failureReason *string
+	if req.FailureReason != nil {
+		value, err := workloadFailureReasonToString(req.GetFailureReason())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failure_reason: %v", err)
+		}
+		failureReason = &value
+	}
+
+	var failureMessage *string
+	if req.FailureMessage != nil {
+		value := strings.TrimSpace(req.GetFailureMessage())
+		failureMessage = &value
+	}
+
 	var containerRecords []containerRecord
 	var containersJSON *[]byte
 	if req.Containers != nil {
@@ -207,7 +233,7 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 		lastMeteringAt = &value
 	}
 
-	if statusValue == nil && containersJSON == nil && instanceID == nil && removedAt == nil && lastMeteringAt == nil {
+	if statusValue == nil && containersJSON == nil && instanceID == nil && removedAt == nil && lastMeteringAt == nil && failureReason == nil && failureMessage == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 
@@ -223,6 +249,8 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 	workload, err := s.updateWorkload(ctx, workloadUpdateInput{
 		ID:             id,
 		Status:         statusValue,
+		FailureReason:  failureReason,
+		FailureMessage: failureMessage,
 		ContainersJSON: containersJSON,
 		InstanceID:     instanceID,
 		RemovedAt:      removedAt,
@@ -374,7 +402,19 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
 	}
-	workloads, nextToken, err := s.listWorkloadsByThread(ctx, threadID, req.GetPageSize(), req.GetPageToken())
+	var agentID *uuid.UUID
+	if req.AgentId != nil {
+		parsed, err := parseUUID(req.GetAgentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+		}
+		agentID = &parsed
+	}
+	statuses, err := workloadStatusesToStrings(req.GetStatusIn())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "status_in: %v", err)
+	}
+	workloads, nextToken, err := s.listWorkloadsByThread(ctx, threadID, agentID, statuses, req.GetPageSize(), req.GetPageToken())
 	if err != nil {
 		var invalidToken *InvalidPageTokenError
 		if errors.As(err, &invalidToken) {
@@ -521,6 +561,12 @@ func (s *Server) updateWorkload(ctx context.Context, input workloadUpdateInput) 
 	if input.Status != nil {
 		addUpdateClause(&clauses, &args, "status", *input.Status)
 	}
+	if input.FailureReason != nil {
+		addUpdateClause(&clauses, &args, "failure_reason", *input.FailureReason)
+	}
+	if input.FailureMessage != nil {
+		addUpdateClause(&clauses, &args, "failure_message", *input.FailureMessage)
+	}
 	if input.ContainersJSON != nil {
 		payload := *input.ContainersJSON
 		if len(payload) == 0 {
@@ -597,25 +643,34 @@ func (s *Server) touchWorkloadForAgent(ctx context.Context, id uuid.UUID, agentI
 	return nil
 }
 
-func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
+func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, agentID *uuid.UUID, statuses []string, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
 	limit := normalizePageSize(pageSize)
 	clauses := []string{fmt.Sprintf("thread_id = $1")}
 	args := []any{threadID}
 
+	if agentID != nil {
+		clauses = append(clauses, fmt.Sprintf("agent_id = $%d", len(args)+1))
+		args = append(args, *agentID)
+	}
+	if len(statuses) > 0 {
+		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[string](statuses))
+	}
+
 	if pageToken != "" {
-		afterID, err := decodePageToken(pageToken)
+		cursor, err := decodeWorkloadCursor(pageToken)
 		if err != nil {
 			return nil, "", InvalidPageToken(err)
 		}
-		clauses = append(clauses, fmt.Sprintf("id > $%d", len(args)+1))
-		args = append(args, afterID)
+		clauses = append(clauses, fmt.Sprintf("(created_at < $%d OR (created_at = $%d AND id < $%d))", len(args)+1, len(args)+1, len(args)+2))
+		args = append(args, cursor.CreatedAt, cursor.ID)
 	}
 
 	query := strings.Builder{}
 	query.WriteString(fmt.Sprintf("SELECT %s FROM workloads", workloadColumns))
 	query.WriteString(" WHERE ")
 	query.WriteString(strings.Join(clauses, " AND "))
-	query.WriteString(fmt.Sprintf(" ORDER BY id ASC LIMIT $%d", len(args)+1))
+	query.WriteString(fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", len(args)+1))
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)
@@ -627,6 +682,7 @@ func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, 
 	workloads := make([]workloadRecord, 0, limit)
 	var (
 		lastID  uuid.UUID
+		lastAt  time.Time
 		hasMore bool
 	)
 	for rows.Next() {
@@ -640,6 +696,7 @@ func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, 
 		}
 		workloads = append(workloads, workload)
 		lastID = workload.Meta.ID
+		lastAt = workload.Meta.CreatedAt
 	}
 	if err := rows.Err(); err != nil {
 		return nil, "", err
@@ -647,9 +704,42 @@ func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, 
 
 	nextToken := ""
 	if hasMore {
-		nextToken = encodePageToken(lastID)
+		nextToken = encodeWorkloadCursor(lastAt, lastID)
 	}
 	return workloads, nextToken, nil
+}
+
+type workloadCursor struct {
+	CreatedAt time.Time
+	ID        uuid.UUID
+}
+
+func encodeWorkloadCursor(createdAt time.Time, id uuid.UUID) string {
+	payload := fmt.Sprintf("%s|%s", createdAt.UTC().Format(time.RFC3339Nano), id.String())
+	return base64.RawURLEncoding.EncodeToString([]byte(payload))
+}
+
+func decodeWorkloadCursor(token string) (workloadCursor, error) {
+	if token == "" {
+		return workloadCursor{}, errors.New("empty token")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return workloadCursor{}, fmt.Errorf("decode token: %w", err)
+	}
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 {
+		return workloadCursor{}, errors.New("invalid token")
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return workloadCursor{}, fmt.Errorf("parse created_at: %w", err)
+	}
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return workloadCursor{}, fmt.Errorf("parse id: %w", err)
+	}
+	return workloadCursor{CreatedAt: createdAt, ID: id}, nil
 }
 
 func (s *Server) listWorkloads(ctx context.Context, statuses []string, organizationID *uuid.UUID, runnerID *uuid.UUID, pendingSample bool, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
@@ -714,6 +804,8 @@ func scanWorkload(row pgx.Row) (workloadRecord, error) {
 	var (
 		workload       workloadRecord
 		containersData []byte
+		failureReason  pgtype.Text
+		failureMessage pgtype.Text
 		instanceID     pgtype.Text
 		removedAt      pgtype.Timestamptz
 		lastMeteringAt pgtype.Timestamptz
@@ -725,6 +817,8 @@ func scanWorkload(row pgx.Row) (workloadRecord, error) {
 		&workload.AgentID,
 		&workload.OrganizationID,
 		&workload.Status,
+		&failureReason,
+		&failureMessage,
 		&containersData,
 		&workload.ZitiIdentityID,
 		&workload.AllocatedCPUMillicores,
@@ -743,6 +837,14 @@ func scanWorkload(row pgx.Row) (workloadRecord, error) {
 	}
 	if err := json.Unmarshal(containersData, &workload.Containers); err != nil {
 		return workloadRecord{}, err
+	}
+	if failureReason.Valid {
+		value := failureReason.String
+		workload.FailureReason = &value
+	}
+	if failureMessage.Valid {
+		value := failureMessage.String
+		workload.FailureMessage = &value
 	}
 	if instanceID.Valid {
 		value := instanceID.String
@@ -789,6 +891,16 @@ func toProtoWorkload(record workloadRecord) (*runnersv1.Workload, error) {
 	}
 	if record.LastMeteringAt != nil {
 		protoWorkload.LastMeteringSampledAt = timestamppb.New(*record.LastMeteringAt)
+	}
+	if record.FailureReason != nil {
+		failureReason, err := workloadFailureReasonFromString(*record.FailureReason)
+		if err != nil {
+			return nil, err
+		}
+		protoWorkload.FailureReason = &failureReason
+	}
+	if record.FailureMessage != nil {
+		protoWorkload.FailureMessage = record.FailureMessage
 	}
 	return protoWorkload, nil
 }
@@ -997,6 +1109,23 @@ func workloadStatusToString(status runnersv1.WorkloadStatus) (string, error) {
 	}
 }
 
+func workloadFailureReasonToString(reason runnersv1.WorkloadFailureReason) (string, error) {
+	switch reason {
+	case runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED:
+		return workloadFailureReasonStartFailed, nil
+	case runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED:
+		return workloadFailureReasonImagePullFailed, nil
+	case runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID:
+		return workloadFailureReasonConfigInvalid, nil
+	case runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP:
+		return workloadFailureReasonCrashloop, nil
+	case runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST:
+		return workloadFailureReasonRuntimeLost, nil
+	default:
+		return "", fmt.Errorf("invalid workload failure reason: %s", reason.String())
+	}
+}
+
 func workloadStatusFromString(value string) (runnersv1.WorkloadStatus, error) {
 	switch value {
 	case workloadStatusStarting:
@@ -1011,6 +1140,23 @@ func workloadStatusFromString(value string) (runnersv1.WorkloadStatus, error) {
 		return runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, nil
 	default:
 		return runnersv1.WorkloadStatus_WORKLOAD_STATUS_UNSPECIFIED, fmt.Errorf("invalid workload status: %s", value)
+	}
+}
+
+func workloadFailureReasonFromString(value string) (runnersv1.WorkloadFailureReason, error) {
+	switch value {
+	case workloadFailureReasonStartFailed:
+		return runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_START_FAILED, nil
+	case workloadFailureReasonImagePullFailed:
+		return runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_IMAGE_PULL_FAILED, nil
+	case workloadFailureReasonConfigInvalid:
+		return runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CONFIG_INVALID, nil
+	case workloadFailureReasonCrashloop:
+		return runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP, nil
+	case workloadFailureReasonRuntimeLost:
+		return runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_RUNTIME_LOST, nil
+	default:
+		return runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_UNSPECIFIED, fmt.Errorf("invalid workload failure reason: %s", value)
 	}
 }
 

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -27,6 +27,8 @@ var workloadRowColumns = []string{
 	"agent_id",
 	"organization_id",
 	"status",
+	"failure_reason",
+	"failure_message",
 	"containers",
 	"ziti_identity_id",
 	"allocated_cpu_millicores",
@@ -70,7 +72,7 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -126,7 +128,7 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -179,7 +181,7 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE %s ORDER BY id ASC LIMIT $1", workloadColumns, pendingSampleClause)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -291,7 +293,7 @@ func TestGetWorkloadRequiresMember(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
@@ -363,7 +365,7 @@ func TestTouchWorkloadRequiresAgentIdentity(t *testing.T) {
 
 	getQuery := fmt.Sprintf(`SELECT %s FROM workloads WHERE id = $1`, workloadColumns)
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 	mockPool.ExpectQuery(regexp.QuoteMeta(getQuery)).WithArgs(workloadID).WillReturnRows(rows)
 
 	srv := New(Options{Pool: mockPool})
@@ -419,7 +421,7 @@ func TestUpdateWorkload(t *testing.T) {
 	}
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("UPDATE workloads SET status = $1, containers = $2, instance_id = $3, updated_at = NOW() WHERE id = $4 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -460,7 +462,7 @@ func TestUpdateWorkloadPublishesNotifications(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	selectRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStarting, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStarting, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
@@ -495,7 +497,7 @@ func TestUpdateWorkloadPublishesNotifications(t *testing.T) {
 	}
 
 	updateRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, updatedContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, updatedContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	updateQuery := fmt.Sprintf("UPDATE workloads SET status = $1, containers = $2, updated_at = NOW() WHERE id = $3 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
@@ -612,7 +614,7 @@ func TestUpdateWorkloadSkipsNotificationsWhenContainersUnchanged(t *testing.T) {
 	}
 
 	selectRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, existingContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, existingContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
@@ -630,7 +632,7 @@ func TestUpdateWorkloadSkipsNotificationsWhenContainersUnchanged(t *testing.T) {
 	}
 
 	updateRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, requestContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, requestContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	updateQuery := fmt.Sprintf("UPDATE workloads SET containers = $1, updated_at = NOW() WHERE id = $2 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
@@ -727,7 +729,7 @@ func TestSoftDeleteWorkload(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStopped, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, now, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStopped, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, now, now, now)
 
 	query := fmt.Sprintf("UPDATE workloads SET status = $1, removed_at = NOW(), updated_at = NOW() WHERE id = $2 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -12,6 +12,7 @@ import (
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pashagolub/pgxmock/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -274,6 +275,111 @@ func TestListWorkloadsRequiresMember(t *testing.T) {
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsByThreadFilters(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+	statuses := []string{workloadStatusRunning, workloadStatusFailed}
+	pageSize := int32(5)
+	limit := normalizePageSize(pageSize)
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 AND agent_id = $2 AND status = ANY($3) ORDER BY created_at DESC, id DESC LIMIT $4", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(threadID, agentID, pgtype.FlatArray[string](statuses), int(limit)+1).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	workloads, nextToken, err := srv.listWorkloadsByThread(context.Background(), threadID, &agentID, statuses, pageSize, "")
+	if err != nil {
+		t.Fatalf("listWorkloadsByThread failed: %v", err)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(workloads))
+	}
+	if nextToken != "" {
+		t.Fatalf("expected empty next token, got %q", nextToken)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsByThreadPagination(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	containersJSON := []byte("[]")
+	pageSize := int32(2)
+	limit := normalizePageSize(pageSize)
+
+	cursorTime := time.Now().UTC().Add(-10 * time.Minute)
+	cursorID := uuid.New()
+	pageToken := encodeWorkloadCursor(cursorTime, cursorID)
+
+	firstAt := cursorTime.Add(-1 * time.Minute)
+	secondAt := cursorTime.Add(-2 * time.Minute)
+	thirdAt := cursorTime.Add(-3 * time.Minute)
+	firstID := uuid.New()
+	secondID := uuid.New()
+	thirdID := uuid.New()
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(firstID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, firstAt, nil, nil, firstAt, firstAt).
+		AddRow(secondID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, secondAt, nil, nil, secondAt, secondAt).
+		AddRow(thirdID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, thirdAt, nil, nil, thirdAt, thirdAt)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 AND (created_at < $2 OR (created_at = $2 AND id < $3)) ORDER BY created_at DESC, id DESC LIMIT $4", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(threadID, cursorTime, cursorID, int(limit)+1).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	workloads, nextToken, err := srv.listWorkloadsByThread(context.Background(), threadID, nil, nil, pageSize, pageToken)
+	if err != nil {
+		t.Fatalf("listWorkloadsByThread failed: %v", err)
+	}
+	if len(workloads) != int(limit) {
+		t.Fatalf("expected %d workloads, got %d", limit, len(workloads))
+	}
+	expectedToken := encodeWorkloadCursor(secondAt, secondID)
+	if nextToken != expectedToken {
+		t.Fatalf("expected next token %q, got %q", expectedToken, nextToken)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsByThreadInvalidPageToken(t *testing.T) {
+	srv := New(Options{})
+	threadID := uuid.New()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, uuid.NewString()))
+	_, err := srv.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{ThreadId: threadID.String(), PageToken: "not-a-token"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument error, got %v", err)
 	}
 }
 
@@ -558,6 +664,93 @@ func TestUpdateWorkloadPublishesNotifications(t *testing.T) {
 	}
 	if !events["workload.status_changed"] {
 		t.Fatal("expected workload.status_changed notification")
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestUpdateWorkloadFailureMetadata(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+	failureReason := workloadFailureReasonCrashloop
+	failureMessage := "back-off"
+
+	selectRows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
+		WithArgs(workloadID).
+		WillReturnRows(selectRows)
+
+	updateRows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, failureReason, failureMessage, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	updateQuery := fmt.Sprintf("UPDATE workloads SET failure_reason = $1, failure_message = $2, updated_at = NOW() WHERE id = $3 RETURNING %s", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
+		WithArgs(failureReason, failureMessage, workloadID).
+		WillReturnRows(updateRows)
+
+	published := make([]*notificationsv1.PublishRequest, 0, 1)
+	notificationsClient := fakeNotificationsClient{publish: func(ctx context.Context, req *notificationsv1.PublishRequest) (*notificationsv1.PublishResponse, error) {
+		published = append(published, req)
+		return &notificationsv1.PublishResponse{}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, NotificationsClient: notificationsClient})
+	reasonEnum := runnersv1.WorkloadFailureReason_WORKLOAD_FAILURE_REASON_CRASHLOOP
+	resp, err := srv.UpdateWorkload(context.Background(), &runnersv1.UpdateWorkloadRequest{
+		Id:             workloadID.String(),
+		FailureReason:  &reasonEnum,
+		FailureMessage: &failureMessage,
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorkload failed: %v", err)
+	}
+	if resp.GetWorkload().GetFailureReason() != reasonEnum {
+		t.Fatalf("expected failure reason %v, got %v", reasonEnum, resp.GetWorkload().GetFailureReason())
+	}
+	if resp.GetWorkload().GetFailureMessage() != failureMessage {
+		t.Fatalf("expected failure message %q, got %q", failureMessage, resp.GetWorkload().GetFailureMessage())
+	}
+	if len(published) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(published))
+	}
+	request := published[0]
+	if request.GetEvent() != "workload.updated" {
+		t.Fatalf("unexpected event: %s", request.GetEvent())
+	}
+	workloadRoom := fmt.Sprintf("workload:%s", workloadID)
+	orgRoom := fmt.Sprintf("organization:%s", organizationID)
+	rooms := request.GetRooms()
+	if len(rooms) != 2 || !hasRoom(rooms, workloadRoom) || !hasRoom(rooms, orgRoom) {
+		t.Fatalf("unexpected workload.updated rooms: %v", rooms)
+	}
+	payload := request.GetPayload().AsMap()
+	if payload["workload_id"] != workloadID.String() {
+		t.Fatalf("unexpected workload_id payload: %v", payload["workload_id"])
+	}
+	if payload["failure_reason"] != failureReason {
+		t.Fatalf("unexpected failure_reason payload: %v", payload["failure_reason"])
+	}
+	if payload["failure_message"] != failureMessage {
+		t.Fatalf("unexpected failure_message payload: %v", payload["failure_message"])
+	}
+	statusValue, ok := payload["status"].(string)
+	if !ok || statusValue != workloadStatusRunning {
+		t.Fatalf("unexpected status payload: %v", payload["status"])
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/migrations/0007_add_workload_failure_fields.sql
+++ b/migrations/0007_add_workload_failure_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE workloads
+ADD COLUMN IF NOT EXISTS failure_reason TEXT,
+ADD COLUMN IF NOT EXISTS failure_message TEXT;


### PR DESCRIPTION
## Summary
- add workload failure reason/message fields plus update handling
- extend ListWorkloadsByThread filtering and pagination ordering
- add migration for workload failure fields

## Testing
- go test ./...
- go vet ./...
- go build ./...

Refs: #161