### PR TITLE
feat(runners): enhance workload and volume lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           buf generate buf.build/agynio/api \
             --include-imports \
+            --path agynio/api/agents/v1 \
+            --path agynio/api/runner/v1 \
             --path agynio/api/runners/v1 \
             --path agynio/api/identity/v1 \
             --path agynio/api/authorization/v1 \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,9 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        uses: agynio/bootstrap/.github/actions/provision@ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
         with:
-          ref: 3f104f8abd35bdf3eef976ae255eaabf69e02977
+          ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
         env:
           TF_VAR_ziti_management_chart_version: "0.10.10"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,7 @@ jobs:
           path: service
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
-        with:
-          ref: ec73ff7f1cfcdca65a829e8e1a0ff8b8c050535d
+        uses: agynio/bootstrap/.github/actions/provision@main
         env:
           TF_VAR_ziti_management_chart_version: "0.10.10"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        with:
+          ref: 3f104f8abd35bdf3eef976ae255eaabf69e02977
         env:
           TF_VAR_ziti_management_chart_version: "0.10.10"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,9 +31,20 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
+      - name: Checkout agents-orchestrator
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/agents-orchestrator
+          ref: cd934479a503d27998d34e01872fa1e885319cb9
+          path: agents-orchestrator
+
       - name: Deploy runners from source
         run: devspace run deploy -n platform
         working-directory: service
+
+      - name: Deploy agents-orchestrator from source
+        run: devspace run deploy -n platform
+        working-directory: agents-orchestrator
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main

--- a/cmd/runners/main.go
+++ b/cmd/runners/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/runners/.gen/go/agynio/api/identity/v1"
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
@@ -65,6 +66,12 @@ func run() error {
 	}
 	defer authorizationConn.Close()
 
+	agentsConn, err := grpc.DialContext(ctx, cfg.AgentsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial agents service: %w", err)
+	}
+	defer agentsConn.Close()
+
 	zitiManagementConn, err := grpc.DialContext(ctx, cfg.ZitiManagementAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial ziti management service: %w", err)
@@ -90,6 +97,7 @@ func run() error {
 		Pool:                 pool,
 		IdentityClient:       identityv1.NewIdentityServiceClient(identityConn),
 		AuthorizationClient:  authorizationv1.NewAuthorizationServiceClient(authorizationConn),
+		AgentsClient:         agentsv1.NewAgentsServiceClient(agentsConn),
 		ZitiManagementClient: zitiMgmtClient,
 		NotificationsClient:  notificationsv1.NewNotificationsServiceClient(notificationsConn),
 		ZitiDialer:           zitiManager,

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -69,6 +69,8 @@ functions:
                   ls -la /opt/app/data/
                   buf generate buf.build/agynio/api \
                     --include-imports \
+                    --path agynio/api/agents/v1 \
+                    --path agynio/api/runner/v1 \
                     --path agynio/api/runners/v1 \
                     --path agynio/api/identity/v1 \
                     --path agynio/api/authorization/v1 \

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 const (
 	defaultIdentityAddress       = "identity:50051"
 	defaultAuthorizationAddress  = "authorization:50051"
+	defaultAgentsAddress         = "agents:50051"
 	defaultZitiManagementAddress = "ziti-management:50051"
 	defaultNotificationsAddress  = "notifications:50051"
 	defaultGRPCAddr              = ":50051"
@@ -20,6 +21,7 @@ type Config struct {
 	DatabaseURL              string
 	IdentityAddress          string
 	AuthorizationAddress     string
+	AgentsAddress            string
 	ZitiManagementAddress    string
 	NotificationsAddress     string
 	ZitiLeaseRenewalInterval time.Duration
@@ -39,6 +41,7 @@ func Load() (Config, error) {
 
 	cfg.IdentityAddress = readEnv("IDENTITY_ADDRESS", defaultIdentityAddress)
 	cfg.AuthorizationAddress = readEnv("AUTHORIZATION_ADDRESS", defaultAuthorizationAddress)
+	cfg.AgentsAddress = readEnv("AGENTS_ADDRESS", defaultAgentsAddress)
 	cfg.ZitiManagementAddress = readEnv("ZITI_MANAGEMENT_ADDRESS", defaultZitiManagementAddress)
 	cfg.NotificationsAddress = readEnv("NOTIFICATIONS_ADDRESS", defaultNotificationsAddress)
 	leaseRenewalInterval := strings.TrimSpace(os.Getenv("ZITI_LEASE_RENEWAL_INTERVAL"))

--- a/internal/server/agents_client.go
+++ b/internal/server/agents_client.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"context"
+
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
+	"google.golang.org/grpc"
+)
+
+type agentsClient interface {
+	GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error)
+	ListVolumes(ctx context.Context, req *agentsv1.ListVolumesRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error)
+	ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error)
+	GetMcp(ctx context.Context, req *agentsv1.GetMcpRequest, opts ...grpc.CallOption) (*agentsv1.GetMcpResponse, error)
+	GetHook(ctx context.Context, req *agentsv1.GetHookRequest, opts ...grpc.CallOption) (*agentsv1.GetHookResponse, error)
+}

--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -27,10 +27,6 @@ func (s *Server) requireClusterAdmin(ctx context.Context, identityID uuid.UUID) 
 	return s.requireRelation(ctx, identityID, clusterAdminRelation, clusterObject)
 }
 
-func (s *Server) clusterAdminAllowed(ctx context.Context, identityID uuid.UUID) (bool, error) {
-	return s.relationAllowed(ctx, identityID, clusterAdminRelation, clusterObject)
-}
-
 func (s *Server) requireOrgOwner(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
 	return s.requireRelation(ctx, identityID, organizationOwnerRelation, organizationObject(organizationID))
 }

--- a/internal/server/grpc_metadata.go
+++ b/internal/server/grpc_metadata.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func outgoingContext(ctx context.Context) context.Context {
+	incoming, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+	if outgoing, ok := metadata.FromOutgoingContext(ctx); ok {
+		return metadata.NewOutgoingContext(ctx, metadata.Join(outgoing, incoming))
+	}
+	return metadata.NewOutgoingContext(ctx, incoming)
+}

--- a/internal/server/grpc_metadata.go
+++ b/internal/server/grpc_metadata.go
@@ -6,13 +6,37 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+var forwardedMetadataKeys = []string{
+	identityMetadata,
+	"x-identity-type",
+	"x-organization-id",
+}
+
 func outgoingContext(ctx context.Context) context.Context {
 	incoming, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ctx
 	}
-	if outgoing, ok := metadata.FromOutgoingContext(ctx); ok {
-		return metadata.NewOutgoingContext(ctx, metadata.Join(outgoing, incoming))
+	forwarded := metadata.MD{}
+	for _, key := range forwardedMetadataKeys {
+		values := incoming.Get(key)
+		if len(values) == 0 {
+			continue
+		}
+		forwarded[key] = append([]string(nil), values...)
 	}
-	return metadata.NewOutgoingContext(ctx, incoming)
+	if len(forwarded) == 0 {
+		return ctx
+	}
+	if outgoing, ok := metadata.FromOutgoingContext(ctx); ok {
+		merged := outgoing.Copy()
+		for key, values := range forwarded {
+			if len(merged.Get(key)) > 0 {
+				continue
+			}
+			merged[key] = append([]string(nil), values...)
+		}
+		return metadata.NewOutgoingContext(ctx, merged)
+	}
+	return metadata.NewOutgoingContext(ctx, forwarded)
 }

--- a/internal/server/list_cursor.go
+++ b/internal/server/list_cursor.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type listCursor struct {
+	Primary string `json:"primary"`
+	ID      string `json:"id"`
+}
+
+func encodeListCursor(primary string, id uuid.UUID) (string, error) {
+	payload, err := json.Marshal(listCursor{Primary: primary, ID: id.String()})
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decodeListCursor(token string) (listCursor, uuid.UUID, error) {
+	if token == "" {
+		return listCursor{}, uuid.UUID{}, errors.New("empty token")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return listCursor{}, uuid.UUID{}, fmt.Errorf("decode token: %w", err)
+	}
+	var cursor listCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return listCursor{}, uuid.UUID{}, fmt.Errorf("parse token: %w", err)
+	}
+	if cursor.ID == "" {
+		return listCursor{}, uuid.UUID{}, errors.New("invalid token")
+	}
+	parsedID, err := uuid.Parse(cursor.ID)
+	if err != nil {
+		return listCursor{}, uuid.UUID{}, fmt.Errorf("parse id: %w", err)
+	}
+	return cursor, parsedID, nil
+}

--- a/internal/server/list_sort.go
+++ b/internal/server/list_sort.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"fmt"
+
+	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
+)
+
+type sortDirection string
+
+const (
+	sortAsc  sortDirection = "ASC"
+	sortDesc sortDirection = "DESC"
+)
+
+func parseSortDirection(direction runnersv1.SortDirection, defaultDirection sortDirection) (sortDirection, error) {
+	switch direction {
+	case runnersv1.SortDirection_SORT_DIRECTION_UNSPECIFIED:
+		return defaultDirection, nil
+	case runnersv1.SortDirection_SORT_DIRECTION_ASC:
+		return sortAsc, nil
+	case runnersv1.SortDirection_SORT_DIRECTION_DESC:
+		return sortDesc, nil
+	default:
+		return "", fmt.Errorf("invalid sort direction: %s", direction.String())
+	}
+}
+
+func (d sortDirection) invert() sortDirection {
+	if d == sortAsc {
+		return sortDesc
+	}
+	return sortAsc
+}

--- a/internal/server/list_utils.go
+++ b/internal/server/list_utils.go
@@ -1,0 +1,31 @@
+package server
+
+import "github.com/google/uuid"
+
+func uniqueUUIDs(values []uuid.UUID) []uuid.UUID {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[uuid.UUID]struct{}, len(values))
+	unique := make([]uuid.UUID, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func compareUUID(a, b uuid.UUID) int {
+	aValue := a.String()
+	bValue := b.String()
+	if aValue < bValue {
+		return -1
+	}
+	if aValue > bValue {
+		return 1
+	}
+	return 0
+}

--- a/internal/server/name_resolution.go
+++ b/internal/server/name_resolution.go
@@ -18,9 +18,10 @@ func (s *Server) resolveAgentNames(ctx context.Context, agentIDs []uuid.UUID) (m
 	if s.agentsClient == nil {
 		return nil, errors.New("agents client not configured")
 	}
+	agentCtx := outgoingContext(ctx)
 	resolved := make(map[uuid.UUID]string, len(agentIDs))
 	for _, agentID := range agentIDs {
-		resp, err := s.agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID.String()})
+		resp, err := s.agentsClient.GetAgent(agentCtx, &agentsv1.GetAgentRequest{Id: agentID.String()})
 		if err != nil {
 			return nil, fmt.Errorf("get agent %s: %w", agentID, err)
 		}
@@ -67,9 +68,10 @@ func (s *Server) resolveVolumeNames(ctx context.Context, volumeIDs []uuid.UUID) 
 	if s.agentsClient == nil {
 		return nil, errors.New("agents client not configured")
 	}
+	volumeCtx := outgoingContext(ctx)
 	resolved := make(map[uuid.UUID]string, len(volumeIDs))
 	for _, volumeID := range volumeIDs {
-		resp, err := s.agentsClient.GetVolume(ctx, &agentsv1.GetVolumeRequest{Id: volumeID.String()})
+		resp, err := s.agentsClient.GetVolume(volumeCtx, &agentsv1.GetVolumeRequest{Id: volumeID.String()})
 		if err != nil {
 			return nil, fmt.Errorf("get volume %s: %w", volumeID, err)
 		}
@@ -90,7 +92,7 @@ func (s *Server) resolveMcpName(ctx context.Context, mcpID uuid.UUID) (string, e
 	if s.agentsClient == nil {
 		return "", errors.New("agents client not configured")
 	}
-	resp, err := s.agentsClient.GetMcp(ctx, &agentsv1.GetMcpRequest{Id: mcpID.String()})
+	resp, err := s.agentsClient.GetMcp(outgoingContext(ctx), &agentsv1.GetMcpRequest{Id: mcpID.String()})
 	if err != nil {
 		return "", fmt.Errorf("get mcp %s: %w", mcpID, err)
 	}
@@ -105,7 +107,7 @@ func (s *Server) resolveHookName(ctx context.Context, hookID uuid.UUID) (string,
 	if s.agentsClient == nil {
 		return "", errors.New("agents client not configured")
 	}
-	resp, err := s.agentsClient.GetHook(ctx, &agentsv1.GetHookRequest{Id: hookID.String()})
+	resp, err := s.agentsClient.GetHook(outgoingContext(ctx), &agentsv1.GetHookRequest{Id: hookID.String()})
 	if err != nil {
 		return "", fmt.Errorf("get hook %s: %w", hookID, err)
 	}

--- a/internal/server/name_resolution.go
+++ b/internal/server/name_resolution.go
@@ -9,7 +9,11 @@ import (
 	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+const missingNamePlaceholder = "unknown"
 
 func (s *Server) resolveAgentNames(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID]string, error) {
 	if len(agentIDs) == 0 {
@@ -23,6 +27,10 @@ func (s *Server) resolveAgentNames(ctx context.Context, agentIDs []uuid.UUID) (m
 	for _, agentID := range agentIDs {
 		resp, err := s.agentsClient.GetAgent(agentCtx, &agentsv1.GetAgentRequest{Id: agentID.String()})
 		if err != nil {
+			if isNotFoundGrpcError(err) {
+				resolved[agentID] = missingNamePlaceholder
+				continue
+			}
 			return nil, fmt.Errorf("get agent %s: %w", agentID, err)
 		}
 		agent := resp.GetAgent()
@@ -73,6 +81,10 @@ func (s *Server) resolveVolumeNames(ctx context.Context, volumeIDs []uuid.UUID) 
 	for _, volumeID := range volumeIDs {
 		resp, err := s.agentsClient.GetVolume(volumeCtx, &agentsv1.GetVolumeRequest{Id: volumeID.String()})
 		if err != nil {
+			if isNotFoundGrpcError(err) {
+				resolved[volumeID] = missingNamePlaceholder
+				continue
+			}
 			return nil, fmt.Errorf("get volume %s: %w", volumeID, err)
 		}
 		volume := resp.GetVolume()
@@ -86,6 +98,11 @@ func (s *Server) resolveVolumeNames(ctx context.Context, volumeIDs []uuid.UUID) 
 		resolved[volumeID] = name
 	}
 	return resolved, nil
+}
+
+func isNotFoundGrpcError(err error) bool {
+	statusErr, ok := status.FromError(err)
+	return ok && statusErr.Code() == codes.NotFound
 }
 
 func (s *Server) resolveMcpName(ctx context.Context, mcpID uuid.UUID) (string, error) {

--- a/internal/server/name_resolution.go
+++ b/internal/server/name_resolution.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (s *Server) resolveAgentNames(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+	if len(agentIDs) == 0 {
+		return map[uuid.UUID]string{}, nil
+	}
+	if s.agentsClient == nil {
+		return nil, errors.New("agents client not configured")
+	}
+	resolved := make(map[uuid.UUID]string, len(agentIDs))
+	for _, agentID := range agentIDs {
+		resp, err := s.agentsClient.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID.String()})
+		if err != nil {
+			return nil, fmt.Errorf("get agent %s: %w", agentID, err)
+		}
+		agent := resp.GetAgent()
+		if agent == nil {
+			return nil, fmt.Errorf("agent %s not found", agentID)
+		}
+		resolved[agentID] = agent.GetName()
+	}
+	return resolved, nil
+}
+
+func (s *Server) resolveRunnerNames(ctx context.Context, runnerIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+	if len(runnerIDs) == 0 {
+		return map[uuid.UUID]string{}, nil
+	}
+	rows, err := s.pool.Query(ctx, "SELECT id, name FROM runners WHERE id = ANY($1)", pgtype.FlatArray[uuid.UUID](runnerIDs))
+	if err != nil {
+		return nil, fmt.Errorf("list runner names: %w", err)
+	}
+	defer rows.Close()
+
+	resolved := make(map[uuid.UUID]string, len(runnerIDs))
+	for rows.Next() {
+		var (
+			id   uuid.UUID
+			name string
+		)
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, fmt.Errorf("scan runner name: %w", err)
+		}
+		resolved[id] = name
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list runner names: %w", err)
+	}
+	return resolved, nil
+}
+
+func (s *Server) resolveVolumeNames(ctx context.Context, volumeIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+	if len(volumeIDs) == 0 {
+		return map[uuid.UUID]string{}, nil
+	}
+	if s.agentsClient == nil {
+		return nil, errors.New("agents client not configured")
+	}
+	resolved := make(map[uuid.UUID]string, len(volumeIDs))
+	for _, volumeID := range volumeIDs {
+		resp, err := s.agentsClient.GetVolume(ctx, &agentsv1.GetVolumeRequest{Id: volumeID.String()})
+		if err != nil {
+			return nil, fmt.Errorf("get volume %s: %w", volumeID, err)
+		}
+		volume := resp.GetVolume()
+		if volume == nil {
+			return nil, fmt.Errorf("volume %s not found", volumeID)
+		}
+		name := strings.TrimSpace(volume.GetDescription())
+		if name == "" {
+			name = strings.TrimSpace(volume.GetMountPath())
+		}
+		resolved[volumeID] = name
+	}
+	return resolved, nil
+}
+
+func (s *Server) resolveMcpName(ctx context.Context, mcpID uuid.UUID) (string, error) {
+	if s.agentsClient == nil {
+		return "", errors.New("agents client not configured")
+	}
+	resp, err := s.agentsClient.GetMcp(ctx, &agentsv1.GetMcpRequest{Id: mcpID.String()})
+	if err != nil {
+		return "", fmt.Errorf("get mcp %s: %w", mcpID, err)
+	}
+	mcp := resp.GetMcp()
+	if mcp == nil {
+		return "", fmt.Errorf("mcp %s not found", mcpID)
+	}
+	return mcp.GetName(), nil
+}
+
+func (s *Server) resolveHookName(ctx context.Context, hookID uuid.UUID) (string, error) {
+	if s.agentsClient == nil {
+		return "", errors.New("agents client not configured")
+	}
+	resp, err := s.agentsClient.GetHook(ctx, &agentsv1.GetHookRequest{Id: hookID.String()})
+	if err != nil {
+		return "", fmt.Errorf("get hook %s: %w", hookID, err)
+	}
+	hook := resp.GetHook()
+	if hook == nil {
+		return "", fmt.Errorf("hook %s not found", hookID)
+	}
+	name := strings.TrimSpace(hook.GetDescription())
+	if name == "" {
+		name = strings.TrimSpace(hook.GetEvent())
+	}
+	return name, nil
+}

--- a/internal/server/name_resolution_test.go
+++ b/internal/server/name_resolution_test.go
@@ -6,7 +6,9 @@ import (
 
 	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func TestResolveAgentNamesForwardsMetadata(t *testing.T) {
@@ -32,5 +34,45 @@ func TestResolveAgentNamesForwardsMetadata(t *testing.T) {
 	values := gotMetadata.Get(identityMetadata)
 	if len(values) != 1 || values[0] != callerID.String() {
 		t.Fatalf("expected %s to be forwarded, got %v", identityMetadata, values)
+	}
+}
+
+func TestResolveAgentNamesNotFoundUsesPlaceholder(t *testing.T) {
+	agentID := uuid.New()
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return nil, status.Error(codes.NotFound, "agent not found")
+	}}
+
+	srv := New(Options{AgentsClient: agentsClient})
+	resolved, err := srv.resolveAgentNames(context.Background(), []uuid.UUID{agentID})
+	if err != nil {
+		t.Fatalf("resolveAgentNames failed: %v", err)
+	}
+	name, ok := resolved[agentID]
+	if !ok {
+		t.Fatalf("expected agent %s to be resolved", agentID)
+	}
+	if name != missingNamePlaceholder {
+		t.Fatalf("expected placeholder name %q, got %q", missingNamePlaceholder, name)
+	}
+}
+
+func TestResolveVolumeNamesNotFoundUsesPlaceholder(t *testing.T) {
+	volumeID := uuid.New()
+	agentsClient := fakeAgentsClient{getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+		return nil, status.Error(codes.NotFound, "volume not found")
+	}}
+
+	srv := New(Options{AgentsClient: agentsClient})
+	resolved, err := srv.resolveVolumeNames(context.Background(), []uuid.UUID{volumeID})
+	if err != nil {
+		t.Fatalf("resolveVolumeNames failed: %v", err)
+	}
+	name, ok := resolved[volumeID]
+	if !ok {
+		t.Fatalf("expected volume %s to be resolved", volumeID)
+	}
+	if name != missingNamePlaceholder {
+		t.Fatalf("expected placeholder name %q, got %q", missingNamePlaceholder, name)
 	}
 }

--- a/internal/server/name_resolution_test.go
+++ b/internal/server/name_resolution_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestResolveAgentNamesForwardsMetadata(t *testing.T) {
+	agentID := uuid.New()
+	callerID := uuid.New()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+
+	var gotMetadata metadata.MD
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		gotMetadata = md
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: "agent"}}, nil
+	}}
+
+	srv := New(Options{AgentsClient: agentsClient})
+	_, err := srv.resolveAgentNames(ctx, []uuid.UUID{agentID})
+	if err != nil {
+		t.Fatalf("resolveAgentNames failed: %v", err)
+	}
+	if gotMetadata == nil {
+		t.Fatal("expected outgoing metadata")
+	}
+	values := gotMetadata.Get(identityMetadata)
+	if len(values) != 1 || values[0] != callerID.String() {
+		t.Fatalf("expected %s to be forwarded, got %v", identityMetadata, values)
+	}
+}

--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/runners/.gen/go/agynio/api/identity/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
@@ -138,7 +139,56 @@ func (f fakeIdentityClient) ResolveNickname(ctx context.Context, req *identityv1
 func (f fakeIdentityClient) BatchGetNicknames(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
+type fakeAgentsClient struct {
+	getAgent              func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error)
+	getVolume             func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error)
+	listVolumes           func(ctx context.Context, req *agentsv1.ListVolumesRequest) (*agentsv1.ListVolumesResponse, error)
+	listVolumeAttachments func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error)
+	getMcp                func(ctx context.Context, req *agentsv1.GetMcpRequest) (*agentsv1.GetMcpResponse, error)
+	getHook               func(ctx context.Context, req *agentsv1.GetHookRequest) (*agentsv1.GetHookResponse, error)
+}
 
+func (f fakeAgentsClient) GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+	if f.getAgent == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.getAgent(ctx, req)
+}
+
+func (f fakeAgentsClient) GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
+	if f.getVolume == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.getVolume(ctx, req)
+}
+
+func (f fakeAgentsClient) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+	if f.listVolumes == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.listVolumes(ctx, req)
+}
+
+func (f fakeAgentsClient) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+	if f.listVolumeAttachments == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.listVolumeAttachments(ctx, req)
+}
+
+func (f fakeAgentsClient) GetMcp(ctx context.Context, req *agentsv1.GetMcpRequest, opts ...grpc.CallOption) (*agentsv1.GetMcpResponse, error) {
+	if f.getMcp == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.getMcp(ctx, req)
+}
+
+func (f fakeAgentsClient) GetHook(ctx context.Context, req *agentsv1.GetHookRequest, opts ...grpc.CallOption) (*agentsv1.GetHookResponse, error) {
+	if f.getHook == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.getHook(ctx, req)
+}
 type fakeAuthorizationClient struct {
 	check func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error)
 	write func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,8 @@ const (
 	clusterAdminRelation       = "admin"
 	organizationMemberRelation = "member"
 	organizationOwnerRelation  = "owner"
+	organizationViewWorkloads  = "can_view_workloads"
+	organizationViewVolumes    = "can_view_volumes"
 	identityObjectPrefix       = "identity:"
 	organizationObjectPrefix   = "organization:"
 	identityMetadata           = "x-identity-id"
@@ -35,6 +37,7 @@ type Server struct {
 	pool                 dbPool
 	identityClient       identityv1.IdentityServiceClient
 	authorizationClient  authorizationv1.AuthorizationServiceClient
+	agentsClient         agentsClient
 	zitiManagementClient zitimanagementv1.ZitiManagementServiceClient
 	notificationsClient  notificationsv1.NotificationsServiceClient
 	zitiDialer           ZitiDialer
@@ -46,6 +49,7 @@ type Options struct {
 	Pool                 dbPool
 	IdentityClient       identityv1.IdentityServiceClient
 	AuthorizationClient  authorizationv1.AuthorizationServiceClient
+	AgentsClient         agentsClient
 	ZitiManagementClient zitimanagementv1.ZitiManagementServiceClient
 	NotificationsClient  notificationsv1.NotificationsServiceClient
 	ZitiDialer           ZitiDialer
@@ -57,6 +61,7 @@ func New(options Options) *Server {
 		pool:                 options.Pool,
 		identityClient:       options.IdentityClient,
 		authorizationClient:  options.AuthorizationClient,
+		agentsClient:         options.AgentsClient,
 		zitiManagementClient: options.ZitiManagementClient,
 		notificationsClient:  options.NotificationsClient,
 		zitiDialer:           options.ZitiDialer,

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/big"
 	"sort"
 	"strings"
 	"time"
@@ -92,6 +93,24 @@ type volumeListItem struct {
 	record      volumeRecord
 	volumeName  string
 	attachments []*runnersv1.Attachment
+}
+
+type volumeEnrichmentCache struct {
+	volumeNames map[uuid.UUID]string
+	attachments map[uuid.UUID][]*runnersv1.Attachment
+	agentNames  map[uuid.UUID]string
+	mcpNames    map[uuid.UUID]string
+	hookNames   map[uuid.UUID]string
+}
+
+func newVolumeEnrichmentCache() *volumeEnrichmentCache {
+	return &volumeEnrichmentCache{
+		volumeNames: map[uuid.UUID]string{},
+		attachments: map[uuid.UUID][]*runnersv1.Attachment{},
+		agentNames:  map[uuid.UUID]string{},
+		mcpNames:    map[uuid.UUID]string{},
+		hookNames:   map[uuid.UUID]string{},
+	}
 }
 
 func (s *Server) CreateVolume(ctx context.Context, req *runnersv1.CreateVolumeRequest) (*runnersv1.CreateVolumeResponse, error) {
@@ -277,10 +296,11 @@ func (s *Server) GetVolume(ctx context.Context, req *runnersv1.GetVolumeRequest)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.requireOrgMember(ctx, callerID, volume.OrganizationID); err != nil {
+	if err := s.requireRelation(ctx, callerID, organizationViewVolumes, organizationObject(volume.OrganizationID)); err != nil {
 		return nil, err
 	}
-	items, err := s.buildVolumeItems(ctx, []volumeRecord{volume})
+	cache := newVolumeEnrichmentCache()
+	items, err := s.buildVolumeItems(ctx, []volumeRecord{volume}, cache, true)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert volume: %v", err)
 	}
@@ -411,27 +431,22 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 		return nil, status.Errorf(codes.InvalidArgument, "sort: %v", err)
 	}
 
-	records, err := s.listVolumes(ctx, filter)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
+	cache := newVolumeEnrichmentCache()
+	var (
+		pageItems []volumeListItem
+		nextToken string
+	)
+	if sort.Field == volumeSortName {
+		pageItems, nextToken, err = s.listVolumesByName(ctx, filter, sort, req.GetPageSize(), req.GetPageToken(), cache)
+	} else {
+		pageItems, nextToken, err = s.listVolumesPaged(ctx, filter, sort, req.GetPageSize(), req.GetPageToken(), cache)
 	}
-	items, err := s.buildVolumeItems(ctx, records)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "enrich volumes: %v", err)
-	}
-	items = filterVolumeItems(items, filter)
-	sortVolumeItems(items, sort)
-	items, err = applyVolumeCursor(items, sort, req.GetPageToken())
 	if err != nil {
 		var invalidToken *InvalidPageTokenError
 		if errors.As(err, &invalidToken) {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", invalidToken.Err)
 		}
-		return nil, status.Errorf(codes.Internal, "invalid page_token: %v", err)
-	}
-	pageItems, nextToken, err := paginateVolumeItems(items, sort, req.GetPageSize())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "paginate volumes: %v", err)
+		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
 	}
 	protoVolumes := make([]*runnersv1.Volume, 0, len(pageItems))
 	for _, item := range pageItems {
@@ -442,6 +457,125 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 		protoVolumes = append(protoVolumes, volume)
 	}
 	return &runnersv1.ListVolumesResponse{Volumes: protoVolumes, NextPageToken: nextToken}, nil
+}
+
+func (s *Server) paginateVolumeItemsWithAttachments(ctx context.Context, items []volumeListItem, sort volumeListSort, filter volumeListFilter, pageSize int32, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
+	limit := normalizePageSize(pageSize)
+	if len(items) == 0 {
+		return []volumeListItem{}, "", nil
+	}
+	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
+	for _, kind := range filter.AttachedKinds {
+		kindFilter[kind] = true
+	}
+
+	pageItems := make([]volumeListItem, 0, limit+1)
+	for _, item := range items {
+		if err := s.ensureVolumeAttachments(ctx, cache, []uuid.UUID{item.record.VolumeID}); err != nil {
+			return nil, "", err
+		}
+		item.attachments = cache.attachments[item.record.VolumeID]
+		if len(kindFilter) > 0 && !matchesVolumeAttachmentKinds(item.attachments, kindFilter) {
+			continue
+		}
+		pageItems = append(pageItems, item)
+		if len(pageItems) == int(limit)+1 {
+			break
+		}
+	}
+	if len(pageItems) <= int(limit) {
+		return pageItems, "", nil
+	}
+	page := pageItems[:limit]
+	lastItem := page[len(page)-1]
+	primary, err := volumePrimaryValue(lastItem, sort.Field)
+	if err != nil {
+		return nil, "", err
+	}
+	nextToken, err := encodeListCursor(primary, lastItem.record.Meta.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	return page, nextToken, nil
+}
+
+func (s *Server) listVolumesByName(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
+	records, err := s.listVolumes(ctx, filter)
+	if err != nil {
+		return nil, "", err
+	}
+	items, err := s.buildVolumeItems(ctx, records, cache, false)
+	if err != nil {
+		return nil, "", err
+	}
+	items = filterVolumeItemsByName(items, filter.VolumeNameContains)
+	if err := sortVolumeItems(items, sort); err != nil {
+		return nil, "", err
+	}
+	items, err = applyVolumeCursor(items, sort, pageToken)
+	if err != nil {
+		return nil, "", err
+	}
+	return s.paginateVolumeItemsWithAttachments(ctx, items, sort, filter, pageSize, cache)
+}
+
+func (s *Server) listVolumesPaged(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
+	limit := normalizePageSize(pageSize)
+	collected := make([]volumeListItem, 0, limit+1)
+	currentToken := pageToken
+	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
+	for _, kind := range filter.AttachedKinds {
+		kindFilter[kind] = true
+	}
+
+	for {
+		records, nextToken, err := s.listVolumesPage(ctx, filter, sort, pageSize, currentToken)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(records) == 0 {
+			break
+		}
+		items, err := s.buildVolumeItems(ctx, records, cache, false)
+		if err != nil {
+			return nil, "", err
+		}
+		items = filterVolumeItemsByName(items, filter.VolumeNameContains)
+		for _, item := range items {
+			if err := s.ensureVolumeAttachments(ctx, cache, []uuid.UUID{item.record.VolumeID}); err != nil {
+				return nil, "", err
+			}
+			item.attachments = cache.attachments[item.record.VolumeID]
+			if len(kindFilter) > 0 && !matchesVolumeAttachmentKinds(item.attachments, kindFilter) {
+				continue
+			}
+			collected = append(collected, item)
+			if len(collected) == int(limit)+1 {
+				break
+			}
+		}
+		if len(collected) == int(limit)+1 {
+			break
+		}
+		if nextToken == "" {
+			break
+		}
+		currentToken = nextToken
+	}
+	if len(collected) <= int(limit) {
+		return collected, "", nil
+	}
+	page := collected[:limit]
+	lastItem := page[len(page)-1]
+	primary, err := volumePrimaryValue(lastItem, sort.Field)
+	if err != nil {
+		return nil, "", err
+	}
+	nextToken, err := encodeListCursor(primary, lastItem.record.Meta.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	return page, nextToken, nil
 }
 
 func (s *Server) BatchUpdateVolumeSampledAt(ctx context.Context, req *runnersv1.BatchUpdateVolumeSampledAtRequest) (*runnersv1.BatchUpdateVolumeSampledAtResponse, error) {
@@ -616,13 +750,71 @@ func parseVolumeSort(sort *runnersv1.ListVolumesSort) (volumeListSort, error) {
 	return volumeListSort{Field: field, Direction: direction}, nil
 }
 
+func volumeSortColumn(field volumeSortField) (string, error) {
+	switch field {
+	case volumeSortSize:
+		return "volumes.size_gb::numeric", nil
+	case volumeSortStatus:
+		return "volumes.status", nil
+	case volumeSortCreated:
+		return "volumes.created_at", nil
+	default:
+		return "", errors.New("invalid sort field")
+	}
+}
+
+func volumeCursorCast(field volumeSortField) string {
+	if field == volumeSortSize {
+		return "::numeric"
+	}
+	return ""
+}
+
+func parseVolumeSize(value string) (*big.Rat, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, errors.New("size_gb is empty")
+	}
+	size, ok := new(big.Rat).SetString(trimmed)
+	if !ok {
+		return nil, fmt.Errorf("invalid size_gb %q", value)
+	}
+	return size, nil
+}
+
+func compareVolumeSize(a, b string) (int, error) {
+	left, err := parseVolumeSize(a)
+	if err != nil {
+		return 0, err
+	}
+	right, err := parseVolumeSize(b)
+	if err != nil {
+		return 0, err
+	}
+	return left.Cmp(right), nil
+}
+
 func volumeCursorPrimary(field volumeSortField, cursor listCursor) (any, error) {
 	switch field {
 	case volumeSortName:
-		return strings.ToLower(cursor.Primary), nil
+		primary := strings.TrimSpace(cursor.Primary)
+		if primary == "" {
+			return nil, errors.New("cursor primary is empty")
+		}
+		return strings.ToLower(primary), nil
 	case volumeSortSize:
-		return cursor.Primary, nil
+		primary := strings.TrimSpace(cursor.Primary)
+		if primary == "" {
+			return nil, errors.New("cursor primary is empty")
+		}
+		if _, err := parseVolumeSize(primary); err != nil {
+			return nil, err
+		}
+		return primary, nil
 	case volumeSortStatus:
+		if strings.TrimSpace(cursor.Primary) == "" {
+			return nil, errors.New("cursor primary is empty")
+		}
 		return cursor.Primary, nil
 	case volumeSortCreated:
 		createdAt, err := time.Parse(time.RFC3339Nano, cursor.Primary)
@@ -638,9 +830,13 @@ func volumeCursorPrimary(field volumeSortField, cursor listCursor) (any, error) 
 func volumePrimaryValue(item volumeListItem, field volumeSortField) (string, error) {
 	switch field {
 	case volumeSortName:
-		return strings.ToLower(item.volumeName), nil
+		return strings.ToLower(strings.TrimSpace(item.volumeName)), nil
 	case volumeSortSize:
-		return item.record.SizeGB, nil
+		value := strings.TrimSpace(item.record.SizeGB)
+		if _, err := parseVolumeSize(value); err != nil {
+			return "", err
+		}
+		return value, nil
 	case volumeSortStatus:
 		return item.record.Status, nil
 	case volumeSortCreated:
@@ -650,24 +846,24 @@ func volumePrimaryValue(item volumeListItem, field volumeSortField) (string, err
 	}
 }
 
-func compareVolumePrimary(item volumeListItem, other volumeListItem, field volumeSortField) int {
+func compareVolumePrimary(item volumeListItem, other volumeListItem, field volumeSortField) (int, error) {
 	switch field {
 	case volumeSortName:
-		return strings.Compare(strings.ToLower(item.volumeName), strings.ToLower(other.volumeName))
+		return strings.Compare(strings.ToLower(item.volumeName), strings.ToLower(other.volumeName)), nil
 	case volumeSortSize:
-		return strings.Compare(item.record.SizeGB, other.record.SizeGB)
+		return compareVolumeSize(item.record.SizeGB, other.record.SizeGB)
 	case volumeSortStatus:
-		return strings.Compare(item.record.Status, other.record.Status)
+		return strings.Compare(item.record.Status, other.record.Status), nil
 	case volumeSortCreated:
 		if item.record.Meta.CreatedAt.Before(other.record.Meta.CreatedAt) {
-			return -1
+			return -1, nil
 		}
 		if item.record.Meta.CreatedAt.After(other.record.Meta.CreatedAt) {
-			return 1
+			return 1, nil
 		}
-		return 0
+		return 0, nil
 	default:
-		return 0
+		return 0, errors.New("invalid sort field")
 	}
 }
 
@@ -684,7 +880,7 @@ func compareVolumePrimaryToCursor(item volumeListItem, cursorPrimary any, field 
 		if !ok {
 			return 0, errors.New("invalid cursor size")
 		}
-		return strings.Compare(item.record.SizeGB, cursorSize), nil
+		return compareVolumeSize(item.record.SizeGB, cursorSize)
 	case volumeSortStatus:
 		cursorStatus, ok := cursorPrimary.(string)
 		if !ok {
@@ -751,14 +947,109 @@ func (s *Server) listVolumes(ctx context.Context, filter volumeListFilter) ([]vo
 	return volumes, nil
 }
 
+func addVolumeCursorClause(clauses *[]string, args *[]any, column string, direction sortDirection, primary any, id uuid.UUID, cast string) {
+	operator := ">"
+	if direction == sortDesc {
+		operator = "<"
+	}
+	clause := fmt.Sprintf("(%s %s $%d%s OR (%s = $%d%s AND volumes.id > $%d))", column, operator, len(*args)+1, cast, column, len(*args)+1, cast, len(*args)+2)
+	*clauses = append(*clauses, clause)
+	*args = append(*args, primary, id)
+}
+
+func (s *Server) listVolumesPage(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string) ([]volumeRecord, string, error) {
+	limit := normalizePageSize(pageSize)
+	clauses := []string{fmt.Sprintf("volumes.organization_id = $%d", 1)}
+	args := []any{filter.OrganizationID}
+
+	if len(filter.RunnerIDs) > 0 {
+		clauses = append(clauses, fmt.Sprintf("volumes.runner_id = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[uuid.UUID](filter.RunnerIDs))
+	}
+	if len(filter.Statuses) > 0 {
+		clauses = append(clauses, fmt.Sprintf("volumes.status = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[string](filter.Statuses))
+	}
+	if filter.PendingSample {
+		clauses = append(clauses, pendingSampleClause)
+	}
+
+	sortColumn, err := volumeSortColumn(sort.Field)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if pageToken != "" {
+		cursor, cursorID, err := decodeListCursor(pageToken)
+		if err != nil {
+			return nil, "", InvalidPageToken(err)
+		}
+		primaryValue, err := volumeCursorPrimary(sort.Field, cursor)
+		if err != nil {
+			return nil, "", InvalidPageToken(err)
+		}
+		addVolumeCursorClause(&clauses, &args, sortColumn, sort.Direction, primaryValue, cursorID, volumeCursorCast(sort.Field))
+	}
+
+	query := strings.Builder{}
+	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	if len(clauses) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(strings.Join(clauses, " AND "))
+	}
+	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, volumes.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1))
+	args = append(args, int(limit)+1)
+
+	rows, err := s.pool.Query(ctx, query.String(), args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+
+	volumes := make([]volumeRecord, 0, limit)
+	var (
+		lastRecord volumeRecord
+		hasMore    bool
+	)
+	for rows.Next() {
+		if int32(len(volumes)) == limit {
+			hasMore = true
+			break
+		}
+		volume, err := scanVolume(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		volumes = append(volumes, volume)
+		lastRecord = volume
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+
+	nextToken := ""
+	if hasMore {
+		primary, err := volumePrimaryValue(volumeListItem{record: lastRecord}, sort.Field)
+		if err != nil {
+			return nil, "", err
+		}
+		nextToken, err = encodeListCursor(primary, lastRecord.Meta.ID)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	return volumes, nextToken, nil
+}
+
 func (s *Server) listVolumeAttachments(ctx context.Context, volumeID uuid.UUID) ([]*agentsv1.VolumeAttachment, error) {
 	if s.agentsClient == nil {
 		return nil, errors.New("agents client not configured")
 	}
+	attachmentsCtx := outgoingContext(ctx)
 	attachments := []*agentsv1.VolumeAttachment{}
 	pageToken := ""
 	for {
-		resp, err := s.agentsClient.ListVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{
+		resp, err := s.agentsClient.ListVolumeAttachments(attachmentsCtx, &agentsv1.ListVolumeAttachmentsRequest{
 			PageSize:  maxListPageSize,
 			PageToken: pageToken,
 			VolumeId:  volumeID.String(),
@@ -775,35 +1066,104 @@ func (s *Server) listVolumeAttachments(ctx context.Context, volumeID uuid.UUID) 
 	return attachments, nil
 }
 
-func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) ([]volumeListItem, error) {
-	if len(records) == 0 {
-		return []volumeListItem{}, nil
+func (s *Server) ensureVolumeNames(ctx context.Context, cache *volumeEnrichmentCache, volumeIDs []uuid.UUID) error {
+	missing := []uuid.UUID{}
+	for _, volumeID := range uniqueUUIDs(volumeIDs) {
+		if _, ok := cache.volumeNames[volumeID]; ok {
+			continue
+		}
+		missing = append(missing, volumeID)
 	}
-	volumeIDs := make([]uuid.UUID, 0, len(records))
-	for _, record := range records {
-		volumeIDs = append(volumeIDs, record.VolumeID)
+	if len(missing) == 0 {
+		return nil
 	}
-	volumeNames, err := s.resolveVolumeNames(ctx, uniqueUUIDs(volumeIDs))
+	resolved, err := s.resolveVolumeNames(ctx, missing)
 	if err != nil {
-		return nil, err
+		return err
+	}
+	for id, name := range resolved {
+		cache.volumeNames[id] = name
+	}
+	return nil
+}
+
+func (s *Server) ensureAgentNames(ctx context.Context, cache *volumeEnrichmentCache, agentIDs []uuid.UUID) error {
+	missing := []uuid.UUID{}
+	for _, agentID := range uniqueUUIDs(agentIDs) {
+		if _, ok := cache.agentNames[agentID]; ok {
+			continue
+		}
+		missing = append(missing, agentID)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	resolved, err := s.resolveAgentNames(ctx, missing)
+	if err != nil {
+		return err
+	}
+	for id, name := range resolved {
+		cache.agentNames[id] = name
+	}
+	return nil
+}
+
+func (s *Server) ensureMcpNames(ctx context.Context, cache *volumeEnrichmentCache, mcpIDs []uuid.UUID) error {
+	for _, mcpID := range uniqueUUIDs(mcpIDs) {
+		if _, ok := cache.mcpNames[mcpID]; ok {
+			continue
+		}
+		name, err := s.resolveMcpName(ctx, mcpID)
+		if err != nil {
+			return err
+		}
+		cache.mcpNames[mcpID] = name
+	}
+	return nil
+}
+
+func (s *Server) ensureHookNames(ctx context.Context, cache *volumeEnrichmentCache, hookIDs []uuid.UUID) error {
+	for _, hookID := range uniqueUUIDs(hookIDs) {
+		if _, ok := cache.hookNames[hookID]; ok {
+			continue
+		}
+		name, err := s.resolveHookName(ctx, hookID)
+		if err != nil {
+			return err
+		}
+		cache.hookNames[hookID] = name
+	}
+	return nil
+}
+
+func (s *Server) ensureVolumeAttachments(ctx context.Context, cache *volumeEnrichmentCache, volumeIDs []uuid.UUID) error {
+	missing := []uuid.UUID{}
+	for _, volumeID := range uniqueUUIDs(volumeIDs) {
+		if _, ok := cache.attachments[volumeID]; ok {
+			continue
+		}
+		missing = append(missing, volumeID)
+	}
+	if len(missing) == 0 {
+		return nil
 	}
 
-	attachmentsByVolume := make(map[uuid.UUID][]*agentsv1.VolumeAttachment, len(records))
+	attachmentsByVolume := make(map[uuid.UUID][]*agentsv1.VolumeAttachment, len(missing))
 	attachmentAgentIDs := []uuid.UUID{}
 	mcpIDs := []uuid.UUID{}
 	hookIDs := []uuid.UUID{}
 
-	for _, record := range records {
-		attachments, err := s.listVolumeAttachments(ctx, record.VolumeID)
+	for _, volumeID := range missing {
+		attachments, err := s.listVolumeAttachments(ctx, volumeID)
 		if err != nil {
-			return nil, fmt.Errorf("list volume attachments: %w", err)
+			return fmt.Errorf("list volume attachments: %w", err)
 		}
-		attachmentsByVolume[record.VolumeID] = attachments
+		attachmentsByVolume[volumeID] = attachments
 		for _, attachment := range attachments {
 			if attachment.GetAgentId() != "" {
 				parsed, err := parseUUID(attachment.GetAgentId())
 				if err != nil {
-					return nil, fmt.Errorf("attachment agent_id: %w", err)
+					return fmt.Errorf("attachment agent_id: %w", err)
 				}
 				attachmentAgentIDs = append(attachmentAgentIDs, parsed)
 				continue
@@ -811,7 +1171,7 @@ func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) (
 			if attachment.GetMcpId() != "" {
 				parsed, err := parseUUID(attachment.GetMcpId())
 				if err != nil {
-					return nil, fmt.Errorf("attachment mcp_id: %w", err)
+					return fmt.Errorf("attachment mcp_id: %w", err)
 				}
 				mcpIDs = append(mcpIDs, parsed)
 				continue
@@ -819,54 +1179,38 @@ func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) (
 			if attachment.GetHookId() != "" {
 				parsed, err := parseUUID(attachment.GetHookId())
 				if err != nil {
-					return nil, fmt.Errorf("attachment hook_id: %w", err)
+					return fmt.Errorf("attachment hook_id: %w", err)
 				}
 				hookIDs = append(hookIDs, parsed)
 				continue
 			}
-			return nil, errors.New("attachment target missing")
+			return errors.New("attachment target missing")
 		}
 	}
 
-	agentNames, err := s.resolveAgentNames(ctx, uniqueUUIDs(attachmentAgentIDs))
-	if err != nil {
-		return nil, err
+	if err := s.ensureAgentNames(ctx, cache, attachmentAgentIDs); err != nil {
+		return err
 	}
-	mcpNames := make(map[uuid.UUID]string, len(mcpIDs))
-	for _, mcpID := range uniqueUUIDs(mcpIDs) {
-		name, err := s.resolveMcpName(ctx, mcpID)
-		if err != nil {
-			return nil, err
-		}
-		mcpNames[mcpID] = name
+	if err := s.ensureMcpNames(ctx, cache, mcpIDs); err != nil {
+		return err
 	}
-	hookNames := make(map[uuid.UUID]string, len(hookIDs))
-	for _, hookID := range uniqueUUIDs(hookIDs) {
-		name, err := s.resolveHookName(ctx, hookID)
-		if err != nil {
-			return nil, err
-		}
-		hookNames[hookID] = name
+	if err := s.ensureHookNames(ctx, cache, hookIDs); err != nil {
+		return err
 	}
 
-	items := make([]volumeListItem, 0, len(records))
-	for _, record := range records {
-		name, ok := volumeNames[record.VolumeID]
-		if !ok {
-			return nil, fmt.Errorf("volume name missing for %s", record.VolumeID)
-		}
-		attachments := attachmentsByVolume[record.VolumeID]
+	for _, volumeID := range missing {
+		attachments := attachmentsByVolume[volumeID]
 		protoAttachments := make([]*runnersv1.Attachment, 0, len(attachments))
 		for _, attachment := range attachments {
 			switch {
 			case attachment.GetAgentId() != "":
 				parsed, err := parseUUID(attachment.GetAgentId())
 				if err != nil {
-					return nil, fmt.Errorf("attachment agent_id: %w", err)
+					return fmt.Errorf("attachment agent_id: %w", err)
 				}
-				name, ok := agentNames[parsed]
+				name, ok := cache.agentNames[parsed]
 				if !ok {
-					return nil, fmt.Errorf("agent name missing for %s", parsed)
+					return fmt.Errorf("agent name missing for %s", parsed)
 				}
 				protoAttachments = append(protoAttachments, &runnersv1.Attachment{
 					Kind: runnersv1.AttachmentKind_ATTACHMENT_KIND_AGENT,
@@ -876,11 +1220,11 @@ func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) (
 			case attachment.GetMcpId() != "":
 				parsed, err := parseUUID(attachment.GetMcpId())
 				if err != nil {
-					return nil, fmt.Errorf("attachment mcp_id: %w", err)
+					return fmt.Errorf("attachment mcp_id: %w", err)
 				}
-				name, ok := mcpNames[parsed]
+				name, ok := cache.mcpNames[parsed]
 				if !ok {
-					return nil, fmt.Errorf("mcp name missing for %s", parsed)
+					return fmt.Errorf("mcp name missing for %s", parsed)
 				}
 				protoAttachments = append(protoAttachments, &runnersv1.Attachment{
 					Kind: runnersv1.AttachmentKind_ATTACHMENT_KIND_MCP,
@@ -890,11 +1234,11 @@ func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) (
 			case attachment.GetHookId() != "":
 				parsed, err := parseUUID(attachment.GetHookId())
 				if err != nil {
-					return nil, fmt.Errorf("attachment hook_id: %w", err)
+					return fmt.Errorf("attachment hook_id: %w", err)
 				}
-				name, ok := hookNames[parsed]
+				name, ok := cache.hookNames[parsed]
 				if !ok {
-					return nil, fmt.Errorf("hook name missing for %s", parsed)
+					return fmt.Errorf("hook name missing for %s", parsed)
 				}
 				protoAttachments = append(protoAttachments, &runnersv1.Attachment{
 					Kind: runnersv1.AttachmentKind_ATTACHMENT_KIND_HOOK,
@@ -902,69 +1246,125 @@ func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) (
 					Name: name,
 				})
 			default:
-				return nil, errors.New("attachment target missing")
+				return errors.New("attachment target missing")
 			}
 		}
-		items = append(items, volumeListItem{record: record, volumeName: name, attachments: protoAttachments})
+		cache.attachments[volumeID] = protoAttachments
+	}
+	return nil
+}
+
+func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord, cache *volumeEnrichmentCache, includeAttachments bool) ([]volumeListItem, error) {
+	if len(records) == 0 {
+		return []volumeListItem{}, nil
+	}
+	volumeIDs := make([]uuid.UUID, 0, len(records))
+	for _, record := range records {
+		volumeIDs = append(volumeIDs, record.VolumeID)
+	}
+	if err := s.ensureVolumeNames(ctx, cache, volumeIDs); err != nil {
+		return nil, err
+	}
+	if includeAttachments {
+		if err := s.ensureVolumeAttachments(ctx, cache, volumeIDs); err != nil {
+			return nil, err
+		}
+	}
+
+	items := make([]volumeListItem, 0, len(records))
+	for _, record := range records {
+		name, ok := cache.volumeNames[record.VolumeID]
+		if !ok {
+			return nil, fmt.Errorf("volume name missing for %s", record.VolumeID)
+		}
+		attachments := []*runnersv1.Attachment{}
+		if includeAttachments {
+			attachments = cache.attachments[record.VolumeID]
+		}
+		items = append(items, volumeListItem{record: record, volumeName: name, attachments: attachments})
 	}
 	return items, nil
 }
 
-func filterVolumeItems(items []volumeListItem, filter volumeListFilter) []volumeListItem {
+func filterVolumeItemsByName(items []volumeListItem, nameFilter string) []volumeListItem {
 	if len(items) == 0 {
 		return items
 	}
-	nameFilter := strings.TrimSpace(filter.VolumeNameContains)
-	nameFilter = strings.ToLower(nameFilter)
-	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
-	for _, kind := range filter.AttachedKinds {
-		kindFilter[kind] = true
+	nameFilter = strings.ToLower(strings.TrimSpace(nameFilter))
+	if nameFilter == "" {
+		return items
 	}
-
 	filtered := make([]volumeListItem, 0, len(items))
 	for _, item := range items {
-		if nameFilter != "" && !strings.Contains(strings.ToLower(item.volumeName), nameFilter) {
-			continue
+		if strings.Contains(strings.ToLower(item.volumeName), nameFilter) {
+			filtered = append(filtered, item)
 		}
-		if len(kindFilter) > 0 {
-			if len(item.attachments) == 0 {
-				if !kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_UNATTACHED] {
-					continue
-				}
-			} else {
-				matches := false
-				for _, attachment := range item.attachments {
-					switch attachment.GetKind() {
-					case runnersv1.AttachmentKind_ATTACHMENT_KIND_AGENT:
-						if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_AGENT] {
-							matches = true
-						}
-					case runnersv1.AttachmentKind_ATTACHMENT_KIND_MCP:
-						if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_MCP] {
-							matches = true
-						}
-					case runnersv1.AttachmentKind_ATTACHMENT_KIND_HOOK:
-						if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_HOOK] {
-							matches = true
-						}
-					}
-					if matches {
-						break
-					}
-				}
-				if !matches {
-					continue
-				}
-			}
-		}
-		filtered = append(filtered, item)
 	}
 	return filtered
 }
 
-func sortVolumeItems(items []volumeListItem, sortSpec volumeListSort) {
+func matchesVolumeAttachmentKinds(attachments []*runnersv1.Attachment, kindFilter map[runnersv1.VolumeAttachmentFilterKind]bool) bool {
+	if len(kindFilter) == 0 {
+		return true
+	}
+	if len(attachments) == 0 {
+		return kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_UNATTACHED]
+	}
+	for _, attachment := range attachments {
+		switch attachment.GetKind() {
+		case runnersv1.AttachmentKind_ATTACHMENT_KIND_AGENT:
+			if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_AGENT] {
+				return true
+			}
+		case runnersv1.AttachmentKind_ATTACHMENT_KIND_MCP:
+			if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_MCP] {
+				return true
+			}
+		case runnersv1.AttachmentKind_ATTACHMENT_KIND_HOOK:
+			if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_HOOK] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func filterVolumeItemsByAttachmentKind(items []volumeListItem, filterKinds []runnersv1.VolumeAttachmentFilterKind) []volumeListItem {
+	if len(items) == 0 {
+		return items
+	}
+	if len(filterKinds) == 0 {
+		return items
+	}
+	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
+	for _, kind := range filterKinds {
+		kindFilter[kind] = true
+	}
+	filtered := make([]volumeListItem, 0, len(items))
+	for _, item := range items {
+		if matchesVolumeAttachmentKinds(item.attachments, kindFilter) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func filterVolumeItems(items []volumeListItem, filter volumeListFilter) []volumeListItem {
+	items = filterVolumeItemsByName(items, filter.VolumeNameContains)
+	return filterVolumeItemsByAttachmentKind(items, filter.AttachedKinds)
+}
+
+func sortVolumeItems(items []volumeListItem, sortSpec volumeListSort) error {
+	var sortErr error
 	sort.SliceStable(items, func(i, j int) bool {
-		primaryCmp := compareVolumePrimary(items[i], items[j], sortSpec.Field)
+		if sortErr != nil {
+			return false
+		}
+		primaryCmp, err := compareVolumePrimary(items[i], items[j], sortSpec.Field)
+		if err != nil {
+			sortErr = err
+			return false
+		}
 		if primaryCmp == 0 {
 			return compareUUID(items[i].record.Meta.ID, items[j].record.Meta.ID) < 0
 		}
@@ -973,6 +1373,7 @@ func sortVolumeItems(items []volumeListItem, sortSpec volumeListSort) {
 		}
 		return primaryCmp > 0
 	})
+	return sortErr
 }
 
 func applyVolumeCursor(items []volumeListItem, sort volumeListSort, pageToken string) ([]volumeListItem, error) {

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -1198,6 +1198,9 @@ func (s *Server) listVolumeAttachments(ctx context.Context, volumeID uuid.UUID) 
 			VolumeId:  volumeID.String(),
 		})
 		if err != nil {
+			if isNotFoundGrpcError(err) {
+				return []*agentsv1.VolumeAttachment{}, nil
+			}
 			return nil, err
 		}
 		attachments = append(attachments, resp.GetVolumeAttachments()...)

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"sort"
 	"strings"
 	"time"
 
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
+	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -14,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -58,6 +63,35 @@ type volumeUpdateInput struct {
 	InstanceID     *string
 	RemovedAt      *time.Time
 	LastMeteringAt *time.Time
+}
+
+type volumeListFilter struct {
+	OrganizationID     uuid.UUID
+	RunnerIDs          []uuid.UUID
+	Statuses           []string
+	AttachedKinds      []runnersv1.VolumeAttachmentFilterKind
+	PendingSample      bool
+	VolumeNameContains string
+}
+
+type volumeSortField int
+
+const (
+	volumeSortName volumeSortField = iota
+	volumeSortSize
+	volumeSortStatus
+	volumeSortCreated
+)
+
+type volumeListSort struct {
+	Field     volumeSortField
+	Direction sortDirection
+}
+
+type volumeListItem struct {
+	record      volumeRecord
+	volumeName  string
+	attachments []*runnersv1.Attachment
 }
 
 func (s *Server) CreateVolume(ctx context.Context, req *runnersv1.CreateVolumeRequest) (*runnersv1.CreateVolumeResponse, error) {
@@ -161,6 +195,15 @@ func (s *Server) UpdateVolume(ctx context.Context, req *runnersv1.UpdateVolumeRe
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 
+	var existingVolume *volumeRecord
+	if s.notificationsClient != nil && (statusValue != nil || instanceID != nil || removedAt != nil) {
+		volume, err := s.getVolumeByID(ctx, id)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		existingVolume = &volume
+	}
+
 	volume, err := s.updateVolume(ctx, volumeUpdateInput{
 		ID:             id,
 		Status:         statusValue,
@@ -171,11 +214,54 @@ func (s *Server) UpdateVolume(ctx context.Context, req *runnersv1.UpdateVolumeRe
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if existingVolume != nil {
+		statusChanged := statusValue != nil && *statusValue != existingVolume.Status
+		instanceChanged := instanceID != nil && (existingVolume.InstanceID == nil || *instanceID != *existingVolume.InstanceID)
+		removedChanged := removedAt != nil && (existingVolume.RemovedAt == nil || !existingVolume.RemovedAt.Equal(*removedAt))
+		if statusChanged || instanceChanged || removedChanged {
+			s.publishVolumeUpdateNotification(ctx, volume)
+		}
+	}
 	protoVolume, err := toProtoVolume(volume)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert volume: %v", err)
 	}
 	return &runnersv1.UpdateVolumeResponse{Volume: protoVolume}, nil
+}
+
+func (s *Server) publishVolumeUpdateNotification(ctx context.Context, volume volumeRecord) {
+	if s.notificationsClient == nil {
+		return
+	}
+	payloadFields := map[string]any{
+		"volume_id": volume.Meta.ID.String(),
+		"status":    volume.Status,
+	}
+	payload, err := structpb.NewStruct(payloadFields)
+	if err != nil {
+		log.Printf("runners: build volume notification payload: %v", err)
+		return
+	}
+	rooms := []string{
+		fmt.Sprintf("organization:%s", volume.OrganizationID.String()),
+		fmt.Sprintf("volume:%s", volume.Meta.ID.String()),
+	}
+	s.publishVolumeNotification(ctx, "volume.updated", rooms, payload)
+}
+
+func (s *Server) publishVolumeNotification(ctx context.Context, event string, rooms []string, payload *structpb.Struct) {
+	if s.notificationsClient == nil {
+		return
+	}
+	_, err := s.notificationsClient.Publish(ctx, &notificationsv1.PublishRequest{
+		Event:   event,
+		Rooms:   rooms,
+		Payload: payload,
+		Source:  "runners",
+	})
+	if err != nil {
+		log.Printf("runners: publish %s notification: %v", event, err)
+	}
 }
 
 func (s *Server) GetVolume(ctx context.Context, req *runnersv1.GetVolumeRequest) (*runnersv1.GetVolumeResponse, error) {
@@ -194,7 +280,11 @@ func (s *Server) GetVolume(ctx context.Context, req *runnersv1.GetVolumeRequest)
 	if err := s.requireOrgMember(ctx, callerID, volume.OrganizationID); err != nil {
 		return nil, err
 	}
-	protoVolume, err := toProtoVolume(volume)
+	items, err := s.buildVolumeItems(ctx, []volumeRecord{volume})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "convert volume: %v", err)
+	}
+	protoVolume, err := toProtoVolumeWithEnrichment(items[0].record, items[0].volumeName, items[0].attachments)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert volume: %v", err)
 	}
@@ -248,64 +338,108 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
 	}
-	statuses, err := volumeStatusesToStrings(req.GetStatuses())
+	orgValue := strings.TrimSpace(req.GetOrganizationId())
+	if orgValue == "" {
+		return nil, status.Error(codes.InvalidArgument, "organization_id: value is empty")
+	}
+	organizationID, err := parseUUID(orgValue)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	var organizationID *uuid.UUID
-	if req.OrganizationId != nil {
-		parsed, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	if err := s.requireRelation(ctx, callerID, organizationViewVolumes, organizationObject(organizationID)); err != nil {
+		return nil, err
+	}
+
+	filter := volumeListFilter{OrganizationID: organizationID}
+	pendingSampleSet := false
+	if req.Filter != nil {
+		filter.RunnerIDs = make([]uuid.UUID, 0, len(req.Filter.RunnerIdIn))
+		for _, runnerValue := range req.Filter.RunnerIdIn {
+			parsed, err := parseUUID(runnerValue)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "filter.runner_id_in: %v", err)
+			}
+			filter.RunnerIDs = append(filter.RunnerIDs, parsed)
 		}
-		organizationID = &parsed
+		filter.AttachedKinds = make([]runnersv1.VolumeAttachmentFilterKind, 0, len(req.Filter.AttachedToKindIn))
+		for _, kind := range req.Filter.AttachedToKindIn {
+			switch kind {
+			case runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_UNSPECIFIED:
+				return nil, status.Error(codes.InvalidArgument, "filter.attached_to_kind_in: unspecified kind")
+			case runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_AGENT,
+				runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_MCP,
+				runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_HOOK,
+				runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_UNATTACHED:
+				filter.AttachedKinds = append(filter.AttachedKinds, kind)
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "filter.attached_to_kind_in: %s", kind.String())
+			}
+		}
+		if req.Filter.PendingSample != nil {
+			filter.PendingSample = req.Filter.GetPendingSample()
+			pendingSampleSet = true
+		}
+		if req.Filter.VolumeNameSubstring != nil {
+			filter.VolumeNameContains = strings.TrimSpace(req.Filter.GetVolumeNameSubstring())
+		}
 	}
-	var runnerID *uuid.UUID
+
 	if req.RunnerId != nil {
 		parsed, err := parseUUID(req.GetRunnerId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 		}
-		runnerID = &parsed
+		filter.RunnerIDs = append(filter.RunnerIDs, parsed)
+	}
+	if req.PendingSample != nil && !pendingSampleSet {
+		filter.PendingSample = req.GetPendingSample()
 	}
 
-	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	statusFilters := make([]runnersv1.VolumeStatus, 0)
+	if req.Filter != nil {
+		statusFilters = append(statusFilters, req.Filter.StatusIn...)
+	}
+	statusFilters = append(statusFilters, req.GetStatuses()...)
+	statuses, err := volumeStatusesToStrings(statusFilters)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
 	}
-	if organizationID != nil && !isClusterAdmin {
-		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
-			return nil, err
-		}
+	filter.Statuses = statuses
+
+	sort, err := parseVolumeSort(req.GetSort())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "sort: %v", err)
 	}
 
-	pendingSample := req.PendingSample != nil && req.GetPendingSample()
-
-	volumes, nextToken, err := s.listVolumes(ctx, statuses, organizationID, runnerID, pendingSample, req.GetPageSize(), req.GetPageToken())
+	records, err := s.listVolumes(ctx, filter)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
+	}
+	items, err := s.buildVolumeItems(ctx, records)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "enrich volumes: %v", err)
+	}
+	items = filterVolumeItems(items, filter)
+	sortVolumeItems(items, sort)
+	items, err = applyVolumeCursor(items, sort, req.GetPageToken())
 	if err != nil {
 		var invalidToken *InvalidPageTokenError
 		if errors.As(err, &invalidToken) {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", invalidToken.Err)
 		}
-		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
+		return nil, status.Errorf(codes.Internal, "invalid page_token: %v", err)
 	}
-	if organizationID == nil && !isClusterAdmin {
-		memberCache := map[uuid.UUID]bool{}
-		filtered := make([]volumeRecord, 0, len(volumes))
-		for _, volume := range volumes {
-			allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
-			if err != nil {
-				return nil, err
-			}
-			if allowed {
-				filtered = append(filtered, volume)
-			}
-		}
-		volumes = filtered
-	}
-	protoVolumes, err := toProtoVolumeList(volumes)
+	pageItems, nextToken, err := paginateVolumeItems(items, sort, req.GetPageSize())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "convert volumes: %v", err)
+		return nil, status.Errorf(codes.Internal, "paginate volumes: %v", err)
+	}
+	protoVolumes := make([]*runnersv1.Volume, 0, len(pageItems))
+	for _, item := range pageItems {
+		volume, err := toProtoVolumeWithEnrichment(item.record, item.volumeName, item.attachments)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "convert volume: %v", err)
+		}
+		protoVolumes = append(protoVolumes, volume)
 	}
 	return &runnersv1.ListVolumesResponse{Volumes: protoVolumes, NextPageToken: nextToken}, nil
 }
@@ -453,54 +587,441 @@ func (s *Server) listVolumesByThread(ctx context.Context, threadID uuid.UUID, pa
 	return volumes, nextToken, nil
 }
 
-func (s *Server) listVolumes(ctx context.Context, statuses []string, organizationID *uuid.UUID, runnerID *uuid.UUID, pendingSample bool, pageSize int32, pageToken string) ([]volumeRecord, string, error) {
-	limit := normalizePageSize(pageSize)
-	query, args, err := buildListQuery(listQueryInput{
-		Table:          "volumes",
-		Columns:        volumeColumns,
-		Statuses:       statuses,
-		OrganizationID: organizationID,
-		RunnerID:       runnerID,
-		PendingSample:  pendingSample,
-		PageToken:      pageToken,
-		Limit:          limit,
-	})
+func parseVolumeSort(sort *runnersv1.ListVolumesSort) (volumeListSort, error) {
+	field := volumeSortName
+	if sort != nil {
+		switch sort.GetField() {
+		case runnersv1.ListVolumesSortField_LIST_VOLUMES_SORT_FIELD_UNSPECIFIED:
+			field = volumeSortName
+		case runnersv1.ListVolumesSortField_LIST_VOLUMES_SORT_FIELD_NAME:
+			field = volumeSortName
+		case runnersv1.ListVolumesSortField_LIST_VOLUMES_SORT_FIELD_SIZE:
+			field = volumeSortSize
+		case runnersv1.ListVolumesSortField_LIST_VOLUMES_SORT_FIELD_STATUS:
+			field = volumeSortStatus
+		case runnersv1.ListVolumesSortField_LIST_VOLUMES_SORT_FIELD_CREATED:
+			field = volumeSortCreated
+		default:
+			return volumeListSort{}, fmt.Errorf("invalid sort field: %s", sort.GetField().String())
+		}
+	}
+	defaultDirection := sortAsc
+	if sort == nil {
+		return volumeListSort{Field: field, Direction: defaultDirection}, nil
+	}
+	direction, err := parseSortDirection(sort.GetDirection(), defaultDirection)
 	if err != nil {
-		return nil, "", err
+		return volumeListSort{}, err
+	}
+	return volumeListSort{Field: field, Direction: direction}, nil
+}
+
+func volumeCursorPrimary(field volumeSortField, cursor listCursor) (any, error) {
+	switch field {
+	case volumeSortName:
+		return strings.ToLower(cursor.Primary), nil
+	case volumeSortSize:
+		return cursor.Primary, nil
+	case volumeSortStatus:
+		return cursor.Primary, nil
+	case volumeSortCreated:
+		createdAt, err := time.Parse(time.RFC3339Nano, cursor.Primary)
+		if err != nil {
+			return nil, fmt.Errorf("parse created_at: %w", err)
+		}
+		return createdAt, nil
+	default:
+		return nil, errors.New("invalid sort field")
+	}
+}
+
+func volumePrimaryValue(item volumeListItem, field volumeSortField) (string, error) {
+	switch field {
+	case volumeSortName:
+		return strings.ToLower(item.volumeName), nil
+	case volumeSortSize:
+		return item.record.SizeGB, nil
+	case volumeSortStatus:
+		return item.record.Status, nil
+	case volumeSortCreated:
+		return item.record.Meta.CreatedAt.UTC().Format(time.RFC3339Nano), nil
+	default:
+		return "", errors.New("invalid sort field")
+	}
+}
+
+func compareVolumePrimary(item volumeListItem, other volumeListItem, field volumeSortField) int {
+	switch field {
+	case volumeSortName:
+		return strings.Compare(strings.ToLower(item.volumeName), strings.ToLower(other.volumeName))
+	case volumeSortSize:
+		return strings.Compare(item.record.SizeGB, other.record.SizeGB)
+	case volumeSortStatus:
+		return strings.Compare(item.record.Status, other.record.Status)
+	case volumeSortCreated:
+		if item.record.Meta.CreatedAt.Before(other.record.Meta.CreatedAt) {
+			return -1
+		}
+		if item.record.Meta.CreatedAt.After(other.record.Meta.CreatedAt) {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+func compareVolumePrimaryToCursor(item volumeListItem, cursorPrimary any, field volumeSortField) (int, error) {
+	switch field {
+	case volumeSortName:
+		cursorName, ok := cursorPrimary.(string)
+		if !ok {
+			return 0, errors.New("invalid cursor name")
+		}
+		return strings.Compare(strings.ToLower(item.volumeName), cursorName), nil
+	case volumeSortSize:
+		cursorSize, ok := cursorPrimary.(string)
+		if !ok {
+			return 0, errors.New("invalid cursor size")
+		}
+		return strings.Compare(item.record.SizeGB, cursorSize), nil
+	case volumeSortStatus:
+		cursorStatus, ok := cursorPrimary.(string)
+		if !ok {
+			return 0, errors.New("invalid cursor status")
+		}
+		return strings.Compare(item.record.Status, cursorStatus), nil
+	case volumeSortCreated:
+		cursorTime, ok := cursorPrimary.(time.Time)
+		if !ok {
+			return 0, errors.New("invalid cursor created_at")
+		}
+		if item.record.Meta.CreatedAt.Before(cursorTime) {
+			return -1, nil
+		}
+		if item.record.Meta.CreatedAt.After(cursorTime) {
+			return 1, nil
+		}
+		return 0, nil
+	default:
+		return 0, errors.New("invalid sort field")
+	}
+}
+
+func (s *Server) listVolumes(ctx context.Context, filter volumeListFilter) ([]volumeRecord, error) {
+	clauses := []string{fmt.Sprintf("organization_id = $%d", 1)}
+	args := []any{filter.OrganizationID}
+
+	if len(filter.RunnerIDs) > 0 {
+		clauses = append(clauses, fmt.Sprintf("runner_id = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[uuid.UUID](filter.RunnerIDs))
+	}
+	if len(filter.Statuses) > 0 {
+		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[string](filter.Statuses))
+	}
+	if filter.PendingSample {
+		clauses = append(clauses, pendingSampleClause)
 	}
 
-	rows, err := s.pool.Query(ctx, query, args...)
+	query := strings.Builder{}
+	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	if len(clauses) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(strings.Join(clauses, " AND "))
+	}
+
+	rows, err := s.pool.Query(ctx, query.String(), args...)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	defer rows.Close()
 
-	volumes := make([]volumeRecord, 0, limit)
-	var (
-		lastID  uuid.UUID
-		hasMore bool
-	)
+	volumes := []volumeRecord{}
 	for rows.Next() {
-		if int32(len(volumes)) == limit {
-			hasMore = true
-			break
-		}
 		volume, err := scanVolume(rows)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 		volumes = append(volumes, volume)
-		lastID = volume.Meta.ID
 	}
 	if err := rows.Err(); err != nil {
-		return nil, "", err
+		return nil, err
+	}
+	return volumes, nil
+}
+
+func (s *Server) listVolumeAttachments(ctx context.Context, volumeID uuid.UUID) ([]*agentsv1.VolumeAttachment, error) {
+	if s.agentsClient == nil {
+		return nil, errors.New("agents client not configured")
+	}
+	attachments := []*agentsv1.VolumeAttachment{}
+	pageToken := ""
+	for {
+		resp, err := s.agentsClient.ListVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{
+			PageSize:  maxListPageSize,
+			PageToken: pageToken,
+			VolumeId:  volumeID.String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		attachments = append(attachments, resp.GetVolumeAttachments()...)
+		if resp.GetNextPageToken() == "" {
+			break
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+	return attachments, nil
+}
+
+func (s *Server) buildVolumeItems(ctx context.Context, records []volumeRecord) ([]volumeListItem, error) {
+	if len(records) == 0 {
+		return []volumeListItem{}, nil
+	}
+	volumeIDs := make([]uuid.UUID, 0, len(records))
+	for _, record := range records {
+		volumeIDs = append(volumeIDs, record.VolumeID)
+	}
+	volumeNames, err := s.resolveVolumeNames(ctx, uniqueUUIDs(volumeIDs))
+	if err != nil {
+		return nil, err
 	}
 
-	nextToken := ""
-	if hasMore {
-		nextToken = encodePageToken(lastID)
+	attachmentsByVolume := make(map[uuid.UUID][]*agentsv1.VolumeAttachment, len(records))
+	attachmentAgentIDs := []uuid.UUID{}
+	mcpIDs := []uuid.UUID{}
+	hookIDs := []uuid.UUID{}
+
+	for _, record := range records {
+		attachments, err := s.listVolumeAttachments(ctx, record.VolumeID)
+		if err != nil {
+			return nil, fmt.Errorf("list volume attachments: %w", err)
+		}
+		attachmentsByVolume[record.VolumeID] = attachments
+		for _, attachment := range attachments {
+			if attachment.GetAgentId() != "" {
+				parsed, err := parseUUID(attachment.GetAgentId())
+				if err != nil {
+					return nil, fmt.Errorf("attachment agent_id: %w", err)
+				}
+				attachmentAgentIDs = append(attachmentAgentIDs, parsed)
+				continue
+			}
+			if attachment.GetMcpId() != "" {
+				parsed, err := parseUUID(attachment.GetMcpId())
+				if err != nil {
+					return nil, fmt.Errorf("attachment mcp_id: %w", err)
+				}
+				mcpIDs = append(mcpIDs, parsed)
+				continue
+			}
+			if attachment.GetHookId() != "" {
+				parsed, err := parseUUID(attachment.GetHookId())
+				if err != nil {
+					return nil, fmt.Errorf("attachment hook_id: %w", err)
+				}
+				hookIDs = append(hookIDs, parsed)
+				continue
+			}
+			return nil, errors.New("attachment target missing")
+		}
 	}
-	return volumes, nextToken, nil
+
+	agentNames, err := s.resolveAgentNames(ctx, uniqueUUIDs(attachmentAgentIDs))
+	if err != nil {
+		return nil, err
+	}
+	mcpNames := make(map[uuid.UUID]string, len(mcpIDs))
+	for _, mcpID := range uniqueUUIDs(mcpIDs) {
+		name, err := s.resolveMcpName(ctx, mcpID)
+		if err != nil {
+			return nil, err
+		}
+		mcpNames[mcpID] = name
+	}
+	hookNames := make(map[uuid.UUID]string, len(hookIDs))
+	for _, hookID := range uniqueUUIDs(hookIDs) {
+		name, err := s.resolveHookName(ctx, hookID)
+		if err != nil {
+			return nil, err
+		}
+		hookNames[hookID] = name
+	}
+
+	items := make([]volumeListItem, 0, len(records))
+	for _, record := range records {
+		name, ok := volumeNames[record.VolumeID]
+		if !ok {
+			return nil, fmt.Errorf("volume name missing for %s", record.VolumeID)
+		}
+		attachments := attachmentsByVolume[record.VolumeID]
+		protoAttachments := make([]*runnersv1.Attachment, 0, len(attachments))
+		for _, attachment := range attachments {
+			switch {
+			case attachment.GetAgentId() != "":
+				parsed, err := parseUUID(attachment.GetAgentId())
+				if err != nil {
+					return nil, fmt.Errorf("attachment agent_id: %w", err)
+				}
+				name, ok := agentNames[parsed]
+				if !ok {
+					return nil, fmt.Errorf("agent name missing for %s", parsed)
+				}
+				protoAttachments = append(protoAttachments, &runnersv1.Attachment{
+					Kind: runnersv1.AttachmentKind_ATTACHMENT_KIND_AGENT,
+					Id:   parsed.String(),
+					Name: name,
+				})
+			case attachment.GetMcpId() != "":
+				parsed, err := parseUUID(attachment.GetMcpId())
+				if err != nil {
+					return nil, fmt.Errorf("attachment mcp_id: %w", err)
+				}
+				name, ok := mcpNames[parsed]
+				if !ok {
+					return nil, fmt.Errorf("mcp name missing for %s", parsed)
+				}
+				protoAttachments = append(protoAttachments, &runnersv1.Attachment{
+					Kind: runnersv1.AttachmentKind_ATTACHMENT_KIND_MCP,
+					Id:   parsed.String(),
+					Name: name,
+				})
+			case attachment.GetHookId() != "":
+				parsed, err := parseUUID(attachment.GetHookId())
+				if err != nil {
+					return nil, fmt.Errorf("attachment hook_id: %w", err)
+				}
+				name, ok := hookNames[parsed]
+				if !ok {
+					return nil, fmt.Errorf("hook name missing for %s", parsed)
+				}
+				protoAttachments = append(protoAttachments, &runnersv1.Attachment{
+					Kind: runnersv1.AttachmentKind_ATTACHMENT_KIND_HOOK,
+					Id:   parsed.String(),
+					Name: name,
+				})
+			default:
+				return nil, errors.New("attachment target missing")
+			}
+		}
+		items = append(items, volumeListItem{record: record, volumeName: name, attachments: protoAttachments})
+	}
+	return items, nil
+}
+
+func filterVolumeItems(items []volumeListItem, filter volumeListFilter) []volumeListItem {
+	if len(items) == 0 {
+		return items
+	}
+	nameFilter := strings.TrimSpace(filter.VolumeNameContains)
+	nameFilter = strings.ToLower(nameFilter)
+	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
+	for _, kind := range filter.AttachedKinds {
+		kindFilter[kind] = true
+	}
+
+	filtered := make([]volumeListItem, 0, len(items))
+	for _, item := range items {
+		if nameFilter != "" && !strings.Contains(strings.ToLower(item.volumeName), nameFilter) {
+			continue
+		}
+		if len(kindFilter) > 0 {
+			if len(item.attachments) == 0 {
+				if !kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_UNATTACHED] {
+					continue
+				}
+			} else {
+				matches := false
+				for _, attachment := range item.attachments {
+					switch attachment.GetKind() {
+					case runnersv1.AttachmentKind_ATTACHMENT_KIND_AGENT:
+						if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_AGENT] {
+							matches = true
+						}
+					case runnersv1.AttachmentKind_ATTACHMENT_KIND_MCP:
+						if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_MCP] {
+							matches = true
+						}
+					case runnersv1.AttachmentKind_ATTACHMENT_KIND_HOOK:
+						if kindFilter[runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_HOOK] {
+							matches = true
+						}
+					}
+					if matches {
+						break
+					}
+				}
+				if !matches {
+					continue
+				}
+			}
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func sortVolumeItems(items []volumeListItem, sortSpec volumeListSort) {
+	sort.SliceStable(items, func(i, j int) bool {
+		primaryCmp := compareVolumePrimary(items[i], items[j], sortSpec.Field)
+		if primaryCmp == 0 {
+			return compareUUID(items[i].record.Meta.ID, items[j].record.Meta.ID) < 0
+		}
+		if sortSpec.Direction == sortAsc {
+			return primaryCmp < 0
+		}
+		return primaryCmp > 0
+	})
+}
+
+func applyVolumeCursor(items []volumeListItem, sort volumeListSort, pageToken string) ([]volumeListItem, error) {
+	if pageToken == "" {
+		return items, nil
+	}
+	cursor, cursorID, err := decodeListCursor(pageToken)
+	if err != nil {
+		return nil, InvalidPageToken(err)
+	}
+	cursorPrimary, err := volumeCursorPrimary(sort.Field, cursor)
+	if err != nil {
+		return nil, InvalidPageToken(err)
+	}
+
+	for idx, item := range items {
+		primaryCmp, err := compareVolumePrimaryToCursor(item, cursorPrimary, sort.Field)
+		if err != nil {
+			return nil, err
+		}
+		if sort.Direction == sortAsc {
+			if primaryCmp > 0 || (primaryCmp == 0 && compareUUID(item.record.Meta.ID, cursorID) > 0) {
+				return items[idx:], nil
+			}
+			continue
+		}
+		if primaryCmp < 0 || (primaryCmp == 0 && compareUUID(item.record.Meta.ID, cursorID) > 0) {
+			return items[idx:], nil
+		}
+	}
+	return []volumeListItem{}, nil
+}
+
+func paginateVolumeItems(items []volumeListItem, sort volumeListSort, pageSize int32) ([]volumeListItem, string, error) {
+	limit := normalizePageSize(pageSize)
+	if len(items) <= int(limit) {
+		return items, "", nil
+	}
+	page := items[:limit]
+	lastItem := page[len(page)-1]
+	primary, err := volumePrimaryValue(lastItem, sort.Field)
+	if err != nil {
+		return nil, "", err
+	}
+	nextToken, err := encodeListCursor(primary, lastItem.record.Meta.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	return page, nextToken, nil
 }
 
 func (s *Server) batchUpdateVolumeSampledAt(ctx context.Context, entries []sampledAtEntry) error {
@@ -575,6 +1096,16 @@ func toProtoVolume(record volumeRecord) (*runnersv1.Volume, error) {
 		protoVolume.LastMeteringSampledAt = timestamppb.New(*record.LastMeteringAt)
 	}
 	return protoVolume, nil
+}
+
+func toProtoVolumeWithEnrichment(record volumeRecord, volumeName string, attachments []*runnersv1.Attachment) (*runnersv1.Volume, error) {
+	volume, err := toProtoVolume(record)
+	if err != nil {
+		return nil, err
+	}
+	volume.VolumeName = volumeName
+	volume.Attachments = attachments
+	return volume, nil
 }
 
 func toProtoVolumeList(records []volumeRecord) ([]*runnersv1.Volume, error) {

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -328,25 +328,18 @@ func (s *Server) ListVolumesByThread(ctx context.Context, req *runnersv1.ListVol
 		}
 		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
 	}
-	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
-	if err != nil {
-		return nil, err
-	}
-	if !isClusterAdmin {
-		memberCache := map[uuid.UUID]bool{}
-		filtered := make([]volumeRecord, 0, len(volumes))
-		for _, volume := range volumes {
-			allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
-			if err != nil {
-				return nil, err
-			}
-			if allowed {
-				filtered = append(filtered, volume)
-			}
+	memberCache := map[uuid.UUID]bool{}
+	filtered := make([]volumeRecord, 0, len(volumes))
+	for _, volume := range volumes {
+		allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
+		if err != nil {
+			return nil, err
 		}
-		volumes = filtered
+		if allowed {
+			filtered = append(filtered, volume)
+		}
 	}
-	protoVolumes, err := toProtoVolumeList(volumes)
+	protoVolumes, err := toProtoVolumeList(filtered)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert volumes: %v", err)
 	}

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -366,14 +366,8 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
-	if err != nil {
+	if err := s.requireRelation(ctx, callerID, organizationViewVolumes, organizationObject(organizationID)); err != nil {
 		return nil, err
-	}
-	if !isClusterAdmin {
-		if err := s.requireRelation(ctx, callerID, organizationViewVolumes, organizationObject(organizationID)); err != nil {
-			return nil, err
-		}
 	}
 
 	filter := volumeListFilter{OrganizationID: organizationID}
@@ -842,18 +836,6 @@ func parseVolumeSize(value string) (*big.Rat, error) {
 	return size, nil
 }
 
-func compareVolumeSize(a, b string) (int, error) {
-	left, err := parseVolumeSize(a)
-	if err != nil {
-		return 0, err
-	}
-	right, err := parseVolumeSize(b)
-	if err != nil {
-		return 0, err
-	}
-	return left.Cmp(right), nil
-}
-
 func volumeCursorPrimary(field volumeSortField, cursor listCursor) (any, error) {
 	switch field {
 	case volumeSortName:
@@ -903,64 +885,6 @@ func volumePrimaryValue(item volumeListItem, field volumeSortField) (string, err
 		return item.record.Meta.CreatedAt.UTC().Format(time.RFC3339Nano), nil
 	default:
 		return "", errors.New("invalid sort field")
-	}
-}
-
-func compareVolumePrimary(item volumeListItem, other volumeListItem, field volumeSortField) (int, error) {
-	switch field {
-	case volumeSortName:
-		return strings.Compare(strings.ToLower(item.volumeName), strings.ToLower(other.volumeName)), nil
-	case volumeSortSize:
-		return compareVolumeSize(item.record.SizeGB, other.record.SizeGB)
-	case volumeSortStatus:
-		return strings.Compare(item.record.Status, other.record.Status), nil
-	case volumeSortCreated:
-		if item.record.Meta.CreatedAt.Before(other.record.Meta.CreatedAt) {
-			return -1, nil
-		}
-		if item.record.Meta.CreatedAt.After(other.record.Meta.CreatedAt) {
-			return 1, nil
-		}
-		return 0, nil
-	default:
-		return 0, errors.New("invalid sort field")
-	}
-}
-
-func compareVolumePrimaryToCursor(item volumeListItem, cursorPrimary any, field volumeSortField) (int, error) {
-	switch field {
-	case volumeSortName:
-		cursorName, ok := cursorPrimary.(string)
-		if !ok {
-			return 0, errors.New("invalid cursor name")
-		}
-		return strings.Compare(strings.ToLower(item.volumeName), cursorName), nil
-	case volumeSortSize:
-		cursorSize, ok := cursorPrimary.(string)
-		if !ok {
-			return 0, errors.New("invalid cursor size")
-		}
-		return compareVolumeSize(item.record.SizeGB, cursorSize)
-	case volumeSortStatus:
-		cursorStatus, ok := cursorPrimary.(string)
-		if !ok {
-			return 0, errors.New("invalid cursor status")
-		}
-		return strings.Compare(item.record.Status, cursorStatus), nil
-	case volumeSortCreated:
-		cursorTime, ok := cursorPrimary.(time.Time)
-		if !ok {
-			return 0, errors.New("invalid cursor created_at")
-		}
-		if item.record.Meta.CreatedAt.Before(cursorTime) {
-			return -1, nil
-		}
-		if item.record.Meta.CreatedAt.After(cursorTime) {
-			return 1, nil
-		}
-		return 0, nil
-	default:
-		return 0, errors.New("invalid sort field")
 	}
 }
 
@@ -1479,84 +1403,6 @@ func matchesVolumeAttachmentKinds(attachments []*runnersv1.Attachment, kindFilte
 		}
 	}
 	return false
-}
-
-func filterVolumeItemsByAttachmentKind(items []volumeListItem, filterKinds []runnersv1.VolumeAttachmentFilterKind) []volumeListItem {
-	if len(items) == 0 {
-		return items
-	}
-	if len(filterKinds) == 0 {
-		return items
-	}
-	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
-	for _, kind := range filterKinds {
-		kindFilter[kind] = true
-	}
-	filtered := make([]volumeListItem, 0, len(items))
-	for _, item := range items {
-		if matchesVolumeAttachmentKinds(item.attachments, kindFilter) {
-			filtered = append(filtered, item)
-		}
-	}
-	return filtered
-}
-
-func filterVolumeItems(items []volumeListItem, filter volumeListFilter) []volumeListItem {
-	items = filterVolumeItemsByName(items, filter.VolumeNameContains)
-	return filterVolumeItemsByAttachmentKind(items, filter.AttachedKinds)
-}
-
-func sortVolumeItems(items []volumeListItem, sortSpec volumeListSort) error {
-	var sortErr error
-	sort.SliceStable(items, func(i, j int) bool {
-		if sortErr != nil {
-			return false
-		}
-		primaryCmp, err := compareVolumePrimary(items[i], items[j], sortSpec.Field)
-		if err != nil {
-			sortErr = err
-			return false
-		}
-		if primaryCmp == 0 {
-			return compareUUID(items[i].record.Meta.ID, items[j].record.Meta.ID) < 0
-		}
-		if sortSpec.Direction == sortAsc {
-			return primaryCmp < 0
-		}
-		return primaryCmp > 0
-	})
-	return sortErr
-}
-
-func applyVolumeCursor(items []volumeListItem, sort volumeListSort, pageToken string) ([]volumeListItem, error) {
-	if pageToken == "" {
-		return items, nil
-	}
-	cursor, cursorID, err := decodeListCursor(pageToken)
-	if err != nil {
-		return nil, InvalidPageToken(err)
-	}
-	cursorPrimary, err := volumeCursorPrimary(sort.Field, cursor)
-	if err != nil {
-		return nil, InvalidPageToken(err)
-	}
-
-	for idx, item := range items {
-		primaryCmp, err := compareVolumePrimaryToCursor(item, cursorPrimary, sort.Field)
-		if err != nil {
-			return nil, err
-		}
-		if sort.Direction == sortAsc {
-			if primaryCmp > 0 || (primaryCmp == 0 && compareUUID(item.record.Meta.ID, cursorID) > 0) {
-				return items[idx:], nil
-			}
-			continue
-		}
-		if primaryCmp < 0 || (primaryCmp == 0 && compareUUID(item.record.Meta.ID, cursorID) > 0) {
-			return items[idx:], nil
-		}
-	}
-	return []volumeListItem{}, nil
 }
 
 func paginateVolumeItems(items []volumeListItem, sort volumeListSort, pageSize int32) ([]volumeListItem, string, error) {

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -366,8 +366,14 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	if err := s.requireRelation(ctx, callerID, organizationViewVolumes, organizationObject(organizationID)); err != nil {
+	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	if err != nil {
 		return nil, err
+	}
+	if !isClusterAdmin {
+		if err := s.requireRelation(ctx, callerID, organizationViewVolumes, organizationObject(organizationID)); err != nil {
+			return nil, err
+		}
 	}
 
 	filter := volumeListFilter{OrganizationID: organizationID}

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -459,34 +459,84 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 	return &runnersv1.ListVolumesResponse{Volumes: protoVolumes, NextPageToken: nextToken}, nil
 }
 
-func (s *Server) paginateVolumeItemsWithAttachments(ctx context.Context, items []volumeListItem, sort volumeListSort, filter volumeListFilter, pageSize int32, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
+func (s *Server) listVolumesByName(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
 	limit := normalizePageSize(pageSize)
-	if len(items) == 0 {
+	volumeIDs, err := s.listVolumeIDs(ctx, filter)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(volumeIDs) == 0 {
+		if pageToken != "" {
+			cursor, _, err := decodeListCursor(pageToken)
+			if err != nil {
+				return nil, "", InvalidPageToken(err)
+			}
+			if _, err := volumeCursorPrimary(sort.Field, cursor); err != nil {
+				return nil, "", InvalidPageToken(err)
+			}
+		}
 		return []volumeListItem{}, "", nil
 	}
+	if err := s.ensureVolumeNames(ctx, cache, volumeIDs); err != nil {
+		return nil, "", err
+	}
+	volumeNames := make(map[uuid.UUID]string, len(volumeIDs))
+	for _, volumeID := range volumeIDs {
+		name, ok := cache.volumeNames[volumeID]
+		if !ok {
+			return nil, "", fmt.Errorf("volume name missing for %s", volumeID)
+		}
+		volumeNames[volumeID] = name
+	}
+
+	nameFilter := strings.ToLower(strings.TrimSpace(filter.VolumeNameContains))
 	kindFilter := map[runnersv1.VolumeAttachmentFilterKind]bool{}
 	for _, kind := range filter.AttachedKinds {
 		kindFilter[kind] = true
 	}
 
-	pageItems := make([]volumeListItem, 0, limit+1)
-	for _, item := range items {
-		if err := s.ensureVolumeAttachments(ctx, cache, []uuid.UUID{item.record.VolumeID}); err != nil {
+	collected := make([]volumeListItem, 0, limit+1)
+	currentToken := pageToken
+	for {
+		records, nextToken, err := s.listVolumesByNamePage(ctx, filter, sort, pageSize, currentToken, volumeNames)
+		if err != nil {
 			return nil, "", err
 		}
-		item.attachments = cache.attachments[item.record.VolumeID]
-		if len(kindFilter) > 0 && !matchesVolumeAttachmentKinds(item.attachments, kindFilter) {
-			continue
-		}
-		pageItems = append(pageItems, item)
-		if len(pageItems) == int(limit)+1 {
+		if len(records) == 0 {
 			break
 		}
+		items, err := s.buildVolumeItems(ctx, records, cache, false)
+		if err != nil {
+			return nil, "", err
+		}
+		for _, item := range items {
+			if nameFilter != "" && !strings.Contains(strings.ToLower(item.volumeName), nameFilter) {
+				continue
+			}
+			if err := s.ensureVolumeAttachments(ctx, cache, []uuid.UUID{item.record.VolumeID}); err != nil {
+				return nil, "", err
+			}
+			item.attachments = cache.attachments[item.record.VolumeID]
+			if len(kindFilter) > 0 && !matchesVolumeAttachmentKinds(item.attachments, kindFilter) {
+				continue
+			}
+			collected = append(collected, item)
+			if len(collected) == int(limit)+1 {
+				break
+			}
+		}
+		if len(collected) == int(limit)+1 {
+			break
+		}
+		if nextToken == "" {
+			break
+		}
+		currentToken = nextToken
 	}
-	if len(pageItems) <= int(limit) {
-		return pageItems, "", nil
+	if len(collected) <= int(limit) {
+		return collected, "", nil
 	}
-	page := pageItems[:limit]
+	page := collected[:limit]
 	lastItem := page[len(page)-1]
 	primary, err := volumePrimaryValue(lastItem, sort.Field)
 	if err != nil {
@@ -497,26 +547,6 @@ func (s *Server) paginateVolumeItemsWithAttachments(ctx context.Context, items [
 		return nil, "", err
 	}
 	return page, nextToken, nil
-}
-
-func (s *Server) listVolumesByName(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
-	records, err := s.listVolumes(ctx, filter)
-	if err != nil {
-		return nil, "", err
-	}
-	items, err := s.buildVolumeItems(ctx, records, cache, false)
-	if err != nil {
-		return nil, "", err
-	}
-	items = filterVolumeItemsByName(items, filter.VolumeNameContains)
-	if err := sortVolumeItems(items, sort); err != nil {
-		return nil, "", err
-	}
-	items, err = applyVolumeCursor(items, sort, pageToken)
-	if err != nil {
-		return nil, "", err
-	}
-	return s.paginateVolumeItemsWithAttachments(ctx, items, sort, filter, pageSize, cache)
 }
 
 func (s *Server) listVolumesPaged(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string, cache *volumeEnrichmentCache) ([]volumeListItem, string, error) {
@@ -770,6 +800,30 @@ func volumeCursorCast(field volumeSortField) string {
 	return ""
 }
 
+func buildVolumeNameSortExpr(volumeNames map[uuid.UUID]string, startIndex int) (string, []any, error) {
+	if len(volumeNames) == 0 {
+		return "", nil, errors.New("volume names empty")
+	}
+	ids := make([]uuid.UUID, 0, len(volumeNames))
+	for id := range volumeNames {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].String() < ids[j].String()
+	})
+
+	parts := make([]string, 0, len(ids))
+	args := make([]any, 0, len(ids)*2)
+	idx := startIndex
+	for _, id := range ids {
+		name := strings.ToLower(strings.TrimSpace(volumeNames[id]))
+		parts = append(parts, fmt.Sprintf("WHEN $%d THEN $%d", idx, idx+1))
+		args = append(args, id, name)
+		idx += 2
+	}
+	return fmt.Sprintf("CASE volumes.volume_id %s END", strings.Join(parts, " ")), args, nil
+}
+
 func parseVolumeSize(value string) (*big.Rat, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -904,16 +958,16 @@ func compareVolumePrimaryToCursor(item volumeListItem, cursorPrimary any, field 
 	}
 }
 
-func (s *Server) listVolumes(ctx context.Context, filter volumeListFilter) ([]volumeRecord, error) {
-	clauses := []string{fmt.Sprintf("organization_id = $%d", 1)}
+func (s *Server) listVolumeIDs(ctx context.Context, filter volumeListFilter) ([]uuid.UUID, error) {
+	clauses := []string{fmt.Sprintf("volumes.organization_id = $%d", 1)}
 	args := []any{filter.OrganizationID}
 
 	if len(filter.RunnerIDs) > 0 {
-		clauses = append(clauses, fmt.Sprintf("runner_id = ANY($%d)", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("volumes.runner_id = ANY($%d)", len(args)+1))
 		args = append(args, pgtype.FlatArray[uuid.UUID](filter.RunnerIDs))
 	}
 	if len(filter.Statuses) > 0 {
-		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("volumes.status = ANY($%d)", len(args)+1))
 		args = append(args, pgtype.FlatArray[string](filter.Statuses))
 	}
 	if filter.PendingSample {
@@ -921,7 +975,7 @@ func (s *Server) listVolumes(ctx context.Context, filter volumeListFilter) ([]vo
 	}
 
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	query.WriteString("SELECT DISTINCT volume_id FROM volumes")
 	if len(clauses) > 0 {
 		query.WriteString(" WHERE ")
 		query.WriteString(strings.Join(clauses, " AND "))
@@ -933,18 +987,18 @@ func (s *Server) listVolumes(ctx context.Context, filter volumeListFilter) ([]vo
 	}
 	defer rows.Close()
 
-	volumes := []volumeRecord{}
+	volumeIDs := []uuid.UUID{}
 	for rows.Next() {
-		volume, err := scanVolume(rows)
-		if err != nil {
+		var volumeID uuid.UUID
+		if err := rows.Scan(&volumeID); err != nil {
 			return nil, err
 		}
-		volumes = append(volumes, volume)
+		volumeIDs = append(volumeIDs, volumeID)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return volumes, nil
+	return volumeIDs, nil
 }
 
 func addVolumeCursorClause(clauses *[]string, args *[]any, column string, direction sortDirection, primary any, id uuid.UUID, cast string) {
@@ -1030,6 +1084,95 @@ func (s *Server) listVolumesPage(ctx context.Context, filter volumeListFilter, s
 	nextToken := ""
 	if hasMore {
 		primary, err := volumePrimaryValue(volumeListItem{record: lastRecord}, sort.Field)
+		if err != nil {
+			return nil, "", err
+		}
+		nextToken, err = encodeListCursor(primary, lastRecord.Meta.ID)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	return volumes, nextToken, nil
+}
+
+func (s *Server) listVolumesByNamePage(ctx context.Context, filter volumeListFilter, sort volumeListSort, pageSize int32, pageToken string, volumeNames map[uuid.UUID]string) ([]volumeRecord, string, error) {
+	limit := normalizePageSize(pageSize)
+	clauses := []string{fmt.Sprintf("volumes.organization_id = $%d", 1)}
+	args := []any{filter.OrganizationID}
+
+	if len(filter.RunnerIDs) > 0 {
+		clauses = append(clauses, fmt.Sprintf("volumes.runner_id = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[uuid.UUID](filter.RunnerIDs))
+	}
+	if len(filter.Statuses) > 0 {
+		clauses = append(clauses, fmt.Sprintf("volumes.status = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[string](filter.Statuses))
+	}
+	if filter.PendingSample {
+		clauses = append(clauses, pendingSampleClause)
+	}
+
+	sortColumn, sortArgs, err := buildVolumeNameSortExpr(volumeNames, len(args)+1)
+	if err != nil {
+		return nil, "", err
+	}
+	args = append(args, sortArgs...)
+
+	if pageToken != "" {
+		cursor, cursorID, err := decodeListCursor(pageToken)
+		if err != nil {
+			return nil, "", InvalidPageToken(err)
+		}
+		primaryValue, err := volumeCursorPrimary(sort.Field, cursor)
+		if err != nil {
+			return nil, "", InvalidPageToken(err)
+		}
+		addVolumeCursorClause(&clauses, &args, sortColumn, sort.Direction, primaryValue, cursorID, "")
+	}
+
+	query := strings.Builder{}
+	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	if len(clauses) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(strings.Join(clauses, " AND "))
+	}
+	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, volumes.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1))
+	args = append(args, int(limit)+1)
+
+	rows, err := s.pool.Query(ctx, query.String(), args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+
+	volumes := make([]volumeRecord, 0, limit)
+	var (
+		lastRecord volumeRecord
+		hasMore    bool
+	)
+	for rows.Next() {
+		if int32(len(volumes)) == limit {
+			hasMore = true
+			break
+		}
+		volume, err := scanVolume(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		volumes = append(volumes, volume)
+		lastRecord = volume
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+
+	nextToken := ""
+	if hasMore {
+		name, ok := volumeNames[lastRecord.VolumeID]
+		if !ok {
+			return nil, "", fmt.Errorf("volume name missing for %s", lastRecord.VolumeID)
+		}
+		primary, err := volumePrimaryValue(volumeListItem{record: lastRecord, volumeName: name}, sort.Field)
 		if err != nil {
 			return nil, "", err
 		}

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
+	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pashagolub/pgxmock/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -51,12 +54,22 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(organizationID, 51).
+		WithArgs(organizationID).
 		WillReturnRows(rows)
 
-	checkRelations := make([]string, 0, 2)
+	volumeName := "volume-name"
+	agentsClient := fakeAgentsClient{
+		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
+		},
+		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+	}
+
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			relation := req.GetTupleKey().GetRelation()
@@ -79,7 +92,7 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 		},
 	}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
 	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
@@ -92,125 +105,14 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	if resp.GetVolumes()[0].GetOrganizationId() != organizationID.String() {
 		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetVolumes()[0].GetOrganizationId())
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	if resp.GetVolumes()[0].GetVolumeName() != volumeName {
+		t.Fatalf("expected volume name %q, got %q", volumeName, resp.GetVolumes()[0].GetVolumeName())
 	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
-
-	if err := mockPool.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestListVolumesAllowsClusterAdminForOrganization(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	volumeID := uuid.New()
-	volumeResourceID := uuid.New()
-	threadID := uuid.New()
-	runnerID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-
-	rows := pgxmock.NewRows(volumeRowColumns).
-		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(organizationID, 51).
-		WillReturnRows(rows)
-
-	checkRelations := make([]string, 0, 1)
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			if relation != clusterAdminRelation {
-				t.Fatalf("expected cluster admin relation, got %s", relation)
-			}
-			if req.GetTupleKey().GetObject() != clusterObject {
-				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-			}
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
-	organizationIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
-	if err != nil {
-		t.Fatalf("ListVolumes failed: %v", err)
-	}
-	if len(resp.GetVolumes()) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
-	}
-	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
-		t.Fatalf("expected cluster admin check, got %v", checkRelations)
-	}
-
-	if err := mockPool.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestListVolumesAllowsClusterAdminWithoutOrganization(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	volumeID := uuid.New()
-	volumeResourceID := uuid.New()
-	threadID := uuid.New()
-	runnerID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-
-	rows := pgxmock.NewRows(volumeRowColumns).
-		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(runnerID, 51).
-		WillReturnRows(rows)
-
-	checkRelations := make([]string, 0, 1)
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			if relation != clusterAdminRelation {
-				t.Fatalf("expected cluster admin relation, got %s", relation)
-			}
-			if req.GetTupleKey().GetObject() != clusterObject {
-				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-			}
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
-	runnerIDValue := runnerID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{RunnerId: &runnerIDValue})
-	if err != nil {
-		t.Fatalf("ListVolumes failed: %v", err)
-	}
-	if len(resp.GetVolumes()) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
-	}
-	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
-		t.Fatalf("expected cluster admin check, got %v", checkRelations)
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -236,12 +138,22 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 AND runner_id = ANY($2)", volumeColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(runnerID, 51).
+		WithArgs(organizationID, pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
 		WillReturnRows(rows)
 
-	checkRelations := make([]string, 0, 2)
+	volumeName := "volume-name"
+	agentsClient := fakeAgentsClient{
+		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
+		},
+		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+	}
+
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			relation := req.GetTupleKey().GetRelation()
@@ -264,10 +176,11 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 		},
 	}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	runnerIDValue := runnerID.String()
+	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{RunnerId: &runnerIDValue})
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, RunnerId: &runnerIDValue})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
@@ -277,67 +190,11 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	if resp.GetVolumes()[0].GetRunnerId() != runnerID.String() {
 		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetVolumes()[0].GetRunnerId())
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	if resp.GetVolumes()[0].GetVolumeName() != volumeName {
+		t.Fatalf("expected volume name %q, got %q", volumeName, resp.GetVolumes()[0].GetVolumeName())
 	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
-	}
-
-	if err := mockPool.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestListVolumesByThreadAllowsClusterAdmin(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	volumeID := uuid.New()
-	volumeResourceID := uuid.New()
-	threadID := uuid.New()
-	runnerID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-
-	rows := pgxmock.NewRows(volumeRowColumns).
-		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE thread_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(threadID, 51).
-		WillReturnRows(rows)
-
-	checkRelations := make([]string, 0, 1)
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			if relation != clusterAdminRelation {
-				t.Fatalf("expected cluster admin relation, got %s", relation)
-			}
-			if req.GetTupleKey().GetObject() != clusterObject {
-				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-			}
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumesByThread(ctx, &runnersv1.ListVolumesByThreadRequest{ThreadId: threadID.String()})
-	if err != nil {
-		t.Fatalf("ListVolumesByThread failed: %v", err)
-	}
-	if len(resp.GetVolumes()) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
-	}
-	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
-		t.Fatalf("expected cluster admin check, got %v", checkRelations)
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -363,12 +220,22 @@ func TestListVolumesPendingSample(t *testing.T) {
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE %s ORDER BY id ASC LIMIT $1", volumeColumns, pendingSampleClause)
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 AND %s", volumeColumns, pendingSampleClause)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(51).
+		WithArgs(organizationID).
 		WillReturnRows(rows)
 
-	checkRelations := make([]string, 0, 2)
+	volumeName := "volume-name"
+	agentsClient := fakeAgentsClient{
+		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
+		},
+		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+	}
+
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			relation := req.GetTupleKey().GetRelation()
@@ -391,10 +258,11 @@ func TestListVolumesPendingSample(t *testing.T) {
 		},
 	}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	pendingSample := true
+	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{PendingSample: &pendingSample})
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, PendingSample: &pendingSample})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
@@ -413,9 +281,200 @@ func TestListVolumesPendingSample(t *testing.T) {
 	}
 }
 
+func TestListVolumesFiltersAttachments(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	otherVolumeID := uuid.New()
+	otherResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now).
+		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID).
+		WillReturnRows(rows)
+
+	volumeName := "data-volume"
+	otherName := "other-volume"
+	agentsClient := fakeAgentsClient{
+		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+			switch req.GetId() {
+			case volumeResourceID.String():
+				return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
+			case otherResourceID.String():
+				return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: otherName}}, nil
+			default:
+				return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{}}, nil
+			}
+		},
+		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			if req.GetVolumeId() == volumeResourceID.String() {
+				return &agentsv1.ListVolumeAttachmentsResponse{
+					VolumeAttachments: []*agentsv1.VolumeAttachment{{
+						VolumeId: volumeResourceID.String(),
+						Target:   &agentsv1.VolumeAttachment_AgentId{AgentId: agentID.String()},
+					}},
+				}, nil
+			}
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+		getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: "agent"}}, nil
+		},
+	}
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{
+		OrganizationId: &organizationIDValue,
+		Filter: &runnersv1.ListVolumesFilter{
+			AttachedToKindIn: []runnersv1.VolumeAttachmentFilterKind{
+				runnersv1.VolumeAttachmentFilterKind_VOLUME_ATTACHMENT_FILTER_KIND_AGENT,
+			},
+			VolumeNameSubstring: &volumeName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListVolumes failed: %v", err)
+	}
+	if len(resp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	volume := resp.GetVolumes()[0]
+	if volume.GetVolumeName() != volumeName {
+		t.Fatalf("expected volume name %q, got %q", volumeName, volume.GetVolumeName())
+	}
+	attachments := volume.GetAttachments()
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if attachments[0].GetKind() != runnersv1.AttachmentKind_ATTACHMENT_KIND_AGENT {
+		t.Fatalf("expected agent attachment, got %v", attachments[0].GetKind())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListVolumesPaginationByName(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	otherVolumeID := uuid.New()
+	otherResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now).
+		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(rows)
+	rowsSecond := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now).
+		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(rowsSecond)
+
+	volumeName := "alpha"
+	otherName := "beta"
+	agentsClient := fakeAgentsClient{
+		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+			switch req.GetId() {
+			case volumeResourceID.String():
+				return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
+			case otherResourceID.String():
+				return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: otherName}}, nil
+			default:
+				return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{}}, nil
+			}
+		},
+		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+	}
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	pageSize := int32(1)
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, PageSize: pageSize})
+	if err != nil {
+		t.Fatalf("ListVolumes failed: %v", err)
+	}
+	if len(resp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	if resp.GetVolumes()[0].GetVolumeName() != volumeName {
+		t.Fatalf("expected first volume name %q, got %q", volumeName, resp.GetVolumes()[0].GetVolumeName())
+	}
+	if resp.GetNextPageToken() == "" {
+		t.Fatal("expected next page token")
+	}
+
+	secondResp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, PageSize: pageSize, PageToken: resp.GetNextPageToken()})
+	if err != nil {
+		t.Fatalf("ListVolumes page 2 failed: %v", err)
+	}
+	if len(secondResp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume on second page, got %d", len(secondResp.GetVolumes()))
+	}
+	if secondResp.GetVolumes()[0].GetVolumeName() != otherName {
+		t.Fatalf("expected second volume name %q, got %q", otherName, secondResp.GetVolumes()[0].GetVolumeName())
+	}
+	if secondResp.GetNextPageToken() != "" {
+		t.Fatalf("expected empty next page token, got %q", secondResp.GetNextPageToken())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestListVolumesInvalidUUID(t *testing.T) {
-	srv := New(Options{})
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+	srv := New(Options{AuthorizationClient: authorizationClient})
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, uuid.NewString()))
+	organizationIDValue := uuid.NewString()
 
 	cases := []struct {
 		name string
@@ -432,7 +491,7 @@ func TestListVolumesInvalidUUID(t *testing.T) {
 			name: "runner_id",
 			req: func() *runnersv1.ListVolumesRequest {
 				value := "not-a-uuid"
-				return &runnersv1.ListVolumesRequest{RunnerId: &value}
+				return &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, RunnerId: &value}
 			}(),
 		},
 	}
@@ -565,6 +624,77 @@ func TestUpdateVolume(t *testing.T) {
 	}
 	if resp.GetVolume().GetInstanceId() != instanceID {
 		t.Fatalf("expected instance id %q, got %q", instanceID, resp.GetVolume().GetInstanceId())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestUpdateVolumePublishesNotification(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+
+	selectRows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusProvisioning, nil, nil, now, now)
+	selectQuery := fmt.Sprintf("SELECT %s FROM volumes WHERE id = $1", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
+		WithArgs(volumeID).
+		WillReturnRows(selectRows)
+
+	updateRows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
+	updateQuery := fmt.Sprintf("UPDATE volumes SET status = $1, updated_at = NOW() WHERE id = $2 RETURNING %s", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
+		WithArgs(volumeStatusActive, volumeID).
+		WillReturnRows(updateRows)
+
+	published := []*notificationsv1.PublishRequest{}
+	notificationsClient := fakeNotificationsClient{publish: func(ctx context.Context, req *notificationsv1.PublishRequest) (*notificationsv1.PublishResponse, error) {
+		published = append(published, req)
+		return &notificationsv1.PublishResponse{}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, NotificationsClient: notificationsClient})
+	_, err = srv.UpdateVolume(context.Background(), &runnersv1.UpdateVolumeRequest{
+		Id:     volumeID.String(),
+		Status: runnersv1.VolumeStatus_VOLUME_STATUS_ACTIVE.Enum(),
+	})
+	if err != nil {
+		t.Fatalf("UpdateVolume failed: %v", err)
+	}
+	if len(published) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(published))
+	}
+	if published[0].GetEvent() != "volume.updated" {
+		t.Fatalf("expected volume.updated event, got %q", published[0].GetEvent())
+	}
+	rooms := published[0].GetRooms()
+	if len(rooms) != 2 {
+		t.Fatalf("expected 2 rooms, got %d", len(rooms))
+	}
+	if rooms[0] != fmt.Sprintf("organization:%s", organizationID.String()) {
+		t.Fatalf("unexpected organization room %q", rooms[0])
+	}
+	if rooms[1] != fmt.Sprintf("volume:%s", volumeID.String()) {
+		t.Fatalf("unexpected volume room %q", rooms[1])
+	}
+	payloadFields := published[0].GetPayload().AsMap()
+	if payloadFields["volume_id"] != volumeID.String() {
+		t.Fatalf("expected payload volume_id %q, got %v", volumeID.String(), payloadFields["volume_id"])
+	}
+	if payloadFields["status"] != volumeStatusActive {
+		t.Fatalf("expected payload status %q, got %v", volumeStatusActive, payloadFields["status"])
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -54,13 +56,20 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID)
+	volumeIDQuery := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1"
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).
 		WithArgs(organizationID).
-		WillReturnRows(rows)
+		WillReturnRows(volumeIDRows)
 
 	volumeName := "volume-name"
+	limit := normalizePageSize(0)
+	sortExpr := "CASE volumes.volume_id WHEN $2 THEN $3 END"
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 ORDER BY %s ASC, volumes.id ASC LIMIT $4", volumeColumns, sortExpr)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, volumeResourceID, strings.ToLower(volumeName), int(limit)+1).
+		WillReturnRows(rows)
+
 	agentsClient := fakeAgentsClient{
 		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
 			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
@@ -138,13 +147,20 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 AND runner_id = ANY($2)", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID)
+	volumeIDQuery := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1 AND volumes.runner_id = ANY($2)"
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).
 		WithArgs(organizationID, pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
-		WillReturnRows(rows)
+		WillReturnRows(volumeIDRows)
 
 	volumeName := "volume-name"
+	limit := normalizePageSize(0)
+	sortExpr := "CASE volumes.volume_id WHEN $3 THEN $4 END"
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 AND volumes.runner_id = ANY($2) ORDER BY %s ASC, volumes.id ASC LIMIT $5", volumeColumns, sortExpr)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID}), volumeResourceID, strings.ToLower(volumeName), int(limit)+1).
+		WillReturnRows(rows)
+
 	agentsClient := fakeAgentsClient{
 		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
 			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
@@ -220,13 +236,20 @@ func TestListVolumesPendingSample(t *testing.T) {
 
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 AND %s", volumeColumns, pendingSampleClause)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID)
+	volumeIDQuery := fmt.Sprintf("SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1 AND %s", pendingSampleClause)
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).
 		WithArgs(organizationID).
-		WillReturnRows(rows)
+		WillReturnRows(volumeIDRows)
 
 	volumeName := "volume-name"
+	limit := normalizePageSize(0)
+	sortExpr := "CASE volumes.volume_id WHEN $2 THEN $3 END"
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 AND %s ORDER BY %s ASC, volumes.id ASC LIMIT $4", volumeColumns, pendingSampleClause, sortExpr)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, volumeResourceID, strings.ToLower(volumeName), int(limit)+1).
+		WillReturnRows(rows)
+
 	agentsClient := fakeAgentsClient{
 		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
 			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
@@ -302,14 +325,34 @@ func TestListVolumesFiltersAttachments(t *testing.T) {
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now).
 		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID).AddRow(otherResourceID)
+	volumeIDQuery := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1"
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).
 		WithArgs(organizationID).
-		WillReturnRows(rows)
+		WillReturnRows(volumeIDRows)
 
 	volumeName := "data-volume"
 	otherName := "other-volume"
+	ids := []uuid.UUID{volumeResourceID, otherResourceID}
+	nameMap := map[uuid.UUID]string{volumeResourceID: volumeName, otherResourceID: otherName}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].String() < ids[j].String()
+	})
+	parts := make([]string, 0, len(ids))
+	args := []any{organizationID}
+	idx := 2
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("WHEN $%d THEN $%d", idx, idx+1))
+		args = append(args, id, strings.ToLower(nameMap[id]))
+		idx += 2
+	}
+	sortExpr := fmt.Sprintf("CASE volumes.volume_id %s END", strings.Join(parts, " "))
+	limit := normalizePageSize(0)
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 ORDER BY %s ASC, volumes.id ASC LIMIT $%d", volumeColumns, sortExpr, len(args)+1)
+	args = append(args, int(limit)+1)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(args...).
+		WillReturnRows(rows)
 	agentsClient := fakeAgentsClient{
 		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
 			switch req.GetId() {
@@ -398,16 +441,45 @@ func TestListVolumesPaginationByName(t *testing.T) {
 	rows := pgxmock.NewRows(volumeRowColumns).
 		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now).
 		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(rows)
-	rowsSecond := pgxmock.NewRows(volumeRowColumns).
-		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now).
-		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(rowsSecond)
+	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID).AddRow(otherResourceID)
+	volumeIDQuery := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1"
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).WithArgs(organizationID).WillReturnRows(volumeIDRows)
 
 	volumeName := "alpha"
 	otherName := "beta"
+	ids := []uuid.UUID{volumeResourceID, otherResourceID}
+	nameMap := map[uuid.UUID]string{volumeResourceID: volumeName, otherResourceID: otherName}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].String() < ids[j].String()
+	})
+	parts := make([]string, 0, len(ids))
+	args := []any{organizationID}
+	idx := 2
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("WHEN $%d THEN $%d", idx, idx+1))
+		args = append(args, id, strings.ToLower(nameMap[id]))
+		idx += 2
+	}
+	sortExpr := fmt.Sprintf("CASE volumes.volume_id %s END", strings.Join(parts, " "))
+	pageSize := int32(1)
+	limit := normalizePageSize(pageSize)
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 ORDER BY %s ASC, volumes.id ASC LIMIT $%d", volumeColumns, sortExpr, len(args)+1)
+	argsWithLimit := append(args, int(limit)+1)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(argsWithLimit...).WillReturnRows(rows)
+	cursorIndex := len(args) + 1
+	cursorIDIndex := len(args) + 2
+	limitIndex := len(args) + 3
+	queryWithCursor := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 AND (%s > $%d OR (%s = $%d AND volumes.id > $%d)) ORDER BY %s ASC, volumes.id ASC LIMIT $%d", volumeColumns, sortExpr, cursorIndex, sortExpr, cursorIndex, cursorIDIndex, sortExpr, limitIndex)
+	argsWithCursor := append(args, strings.ToLower(volumeName), volumeID, int(limit)+1)
+	rowsSecond := pgxmock.NewRows(volumeRowColumns).
+		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(queryWithCursor)).WithArgs(argsWithCursor...).WillReturnRows(rowsSecond)
+
+	volumeIDRowsSecond := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID).AddRow(otherResourceID)
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).WithArgs(organizationID).WillReturnRows(volumeIDRowsSecond)
+	rowsThird := pgxmock.NewRows(volumeRowColumns).
+		AddRow(otherVolumeID, nil, otherResourceID, threadID, runnerID, agentID, organizationID, "20", volumeStatusActive, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(queryWithCursor)).WithArgs(argsWithCursor...).WillReturnRows(rowsThird)
 	agentsClient := fakeAgentsClient{
 		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
 			switch req.GetId() {
@@ -433,7 +505,6 @@ func TestListVolumesPaginationByName(t *testing.T) {
 	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	pageSize := int32(1)
 	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, PageSize: pageSize})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
@@ -515,11 +586,11 @@ func TestListVolumesInvalidPageToken(t *testing.T) {
 
 	organizationID := uuid.New()
 	callerID := uuid.New()
-	rows := pgxmock.NewRows(volumeRowColumns)
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
+	rows := pgxmock.NewRows([]string{"volume_id"})
+	query := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1"
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(rows)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(pgxmock.NewRows(volumeRowColumns))
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(pgxmock.NewRows(volumeRowColumns))
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(pgxmock.NewRows([]string{"volume_id"}))
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(pgxmock.NewRows([]string{"volume_id"}))
 
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
@@ -548,7 +619,7 @@ func TestListVolumesInvalidPageToken(t *testing.T) {
 	}
 }
 
-func TestListVolumesRequiresMember(t *testing.T) {
+func TestListVolumesRequiresViewVolumes(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatalf("failed to create mock pool: %v", err)
@@ -584,7 +655,7 @@ func TestListVolumesRequiresMember(t *testing.T) {
 	}
 }
 
-func TestGetVolumeRequiresMember(t *testing.T) {
+func TestGetVolumeRequiresViewVolumes(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatalf("failed to create mock pool: %v", err)

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"testing"
@@ -506,6 +507,47 @@ func TestListVolumesInvalidUUID(t *testing.T) {
 	}
 }
 
+func TestListVolumesInvalidPageToken(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	rows := pgxmock.NewRows(volumeRowColumns)
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(rows)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(pgxmock.NewRows(volumeRowColumns))
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(organizationID).WillReturnRows(pgxmock.NewRows(volumeRowColumns))
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	organizationIDValue := organizationID.String()
+	validID := uuid.NewString()
+
+	invalidJSONToken := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+	wrongPrimaryToken := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"primary":10,"id":"%s"}`, validID)))
+
+	cases := []string{"not-a-token", invalidJSONToken, wrongPrimaryToken}
+	for _, token := range cases {
+		_, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, PageToken: token})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument error for token %q, got %v", token, err)
+		}
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestListVolumesRequiresMember(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
@@ -515,20 +557,11 @@ func TestListVolumesRequiresMember(t *testing.T) {
 	organizationID := uuid.New()
 	callerID := uuid.New()
 
-	checkRelations := make([]string, 0, 2)
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
 
@@ -539,11 +572,11 @@ func TestListVolumesRequiresMember(t *testing.T) {
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -572,8 +605,10 @@ func TestGetVolumeRequiresMember(t *testing.T) {
 	query := fmt.Sprintf("SELECT %s FROM volumes WHERE id = $1", volumeColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(volumeID).WillReturnRows(rows)
 
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
 			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
@@ -583,6 +618,12 @@ func TestGetVolumeRequiresMember(t *testing.T) {
 	_, err = srv.GetVolume(ctx, &runnersv1.GetVolumeRequest{Id: volumeID.String()})
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -83,7 +83,7 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			gotCheckReqs = append(gotCheckReqs, req)
-			allowed := req.GetTupleKey().GetRelation() != clusterAdminRelation
+			allowed := req.GetTupleKey().GetRelation() == organizationViewVolumes
 			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 		},
 	}
@@ -104,20 +104,14 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	if resp.GetVolumes()[0].GetVolumeName() != volumeName {
 		t.Fatalf("expected volume name %q, got %q", volumeName, resp.GetVolumes()[0].GetVolumeName())
 	}
-	if len(gotCheckReqs) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
 	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewVolumes {
-		t.Fatalf("expected view volumes relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
-		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	if gotCheckReqs[0].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -638,97 +632,19 @@ func TestListVolumesRequiresViewVolumes(t *testing.T) {
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
-	if len(gotCheckReqs) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
 	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewVolumes {
-		t.Fatalf("expected view volumes relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
-		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	if gotCheckReqs[0].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
-}
-
-func TestListVolumesAllowsClusterAdmin(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	volumeID := uuid.New()
-	volumeResourceID := uuid.New()
-	threadID := uuid.New()
-	runnerID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-
-	rows := pgxmock.NewRows(volumeRowColumns).
-		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
-
-	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID)
-	volumeIDQuery := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1"
-	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).
-		WithArgs(organizationID).
-		WillReturnRows(volumeIDRows)
-
-	volumeName := "volume-name"
-	limit := normalizePageSize(0)
-	sortExpr := "CASE volumes.volume_id WHEN $2 THEN $3 END"
-	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 ORDER BY %s ASC, volumes.id ASC LIMIT $4", volumeColumns, sortExpr)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(organizationID, volumeResourceID, strings.ToLower(volumeName), int(limit)+1).
-		WillReturnRows(rows)
-
-	agentsClient := fakeAgentsClient{
-		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
-			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
-		},
-		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
-		},
-	}
-
-	var gotCheckReqs []*authorizationv1.CheckRequest
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReqs = append(gotCheckReqs, req)
-			allowed := req.GetTupleKey().GetRelation() == clusterAdminRelation
-			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
-	organizationIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
-	if err != nil {
-		t.Fatalf("ListVolumes failed: %v", err)
-	}
-	if len(resp.GetVolumes()) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
-	}
-	if len(gotCheckReqs) != 1 {
-		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
-	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-
 	if err := mockPool.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -162,23 +162,8 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				if req.GetTupleKey().GetObject() != clusterObject {
-					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
-					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: true}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
 		},
 	}
 
@@ -251,23 +236,8 @@ func TestListVolumesPendingSample(t *testing.T) {
 	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				if req.GetTupleKey().GetObject() != clusterObject {
-					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
-					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: true}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
 		},
 	}
 
@@ -282,11 +252,8 @@ func TestListVolumesPendingSample(t *testing.T) {
 	if len(resp.GetVolumes()) != 1 {
 		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
-	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -79,26 +79,12 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 		},
 	}
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	var gotCheckReqs []*authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				if req.GetTupleKey().GetObject() != clusterObject {
-					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
-					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: true}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReqs = append(gotCheckReqs, req)
+			allowed := req.GetTupleKey().GetRelation() != clusterAdminRelation
+			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 		},
 	}
 
@@ -118,11 +104,20 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	if resp.GetVolumes()[0].GetVolumeName() != volumeName {
 		t.Fatalf("expected volume name %q, got %q", volumeName, resp.GetVolumes()[0].GetVolumeName())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(gotCheckReqs) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewVolumes {
-		t.Fatalf("expected view volumes relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -628,10 +623,10 @@ func TestListVolumesRequiresViewVolumes(t *testing.T) {
 	organizationID := uuid.New()
 	callerID := uuid.New()
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	var gotCheckReqs []*authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
+			gotCheckReqs = append(gotCheckReqs, req)
 			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
@@ -643,11 +638,95 @@ func TestListVolumesRequiresViewVolumes(t *testing.T) {
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(gotCheckReqs) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewVolumes {
-		t.Fatalf("expected view volumes relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewVolumes {
+		t.Fatalf("expected view volumes relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListVolumesAllowsClusterAdmin(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
+
+	volumeIDRows := pgxmock.NewRows([]string{"volume_id"}).AddRow(volumeResourceID)
+	volumeIDQuery := "SELECT DISTINCT volume_id FROM volumes WHERE volumes.organization_id = $1"
+	mockPool.ExpectQuery(regexp.QuoteMeta(volumeIDQuery)).
+		WithArgs(organizationID).
+		WillReturnRows(volumeIDRows)
+
+	volumeName := "volume-name"
+	limit := normalizePageSize(0)
+	sortExpr := "CASE volumes.volume_id WHEN $2 THEN $3 END"
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE volumes.organization_id = $1 ORDER BY %s ASC, volumes.id ASC LIMIT $4", volumeColumns, sortExpr)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, volumeResourceID, strings.ToLower(volumeName), int(limit)+1).
+		WillReturnRows(rows)
+
+	agentsClient := fakeAgentsClient{
+		getVolume: func(ctx context.Context, req *agentsv1.GetVolumeRequest) (*agentsv1.GetVolumeResponse, error) {
+			return &agentsv1.GetVolumeResponse{Volume: &agentsv1.Volume{Description: volumeName}}, nil
+		},
+		listVolumeAttachments: func(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		},
+	}
+
+	var gotCheckReqs []*authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReqs = append(gotCheckReqs, req)
+			allowed := req.GetTupleKey().GetRelation() == clusterAdminRelation
+			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
+	if err != nil {
+		t.Fatalf("ListVolumes failed: %v", err)
+	}
+	if len(resp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
+	}
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workload_logs.go
+++ b/internal/server/workload_logs.go
@@ -52,7 +52,7 @@ func (s *Server) StreamWorkloadLogs(req *runnerv1.StreamWorkloadLogsRequest, str
 	if err != nil {
 		return toStatusError(err)
 	}
-	if err := s.requireOrgMember(ctx, callerID, workload.OrganizationID); err != nil {
+	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
 		return err
 	}
 

--- a/internal/server/workload_logs_test.go
+++ b/internal/server/workload_logs_test.go
@@ -244,8 +244,10 @@ func TestStreamWorkloadLogsRequiresMember(t *testing.T) {
 		WithArgs(workloadID).
 		WillReturnRows(workloadRows)
 
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
 			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
@@ -264,6 +266,12 @@ func TestStreamWorkloadLogsRequiresMember(t *testing.T) {
 	}, stream)
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected permission denied, got %v", err)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workload_logs_test.go
+++ b/internal/server/workload_logs_test.go
@@ -222,7 +222,7 @@ func TestStreamWorkloadLogsProxiesRunnerStream(t *testing.T) {
 	}
 }
 
-func TestStreamWorkloadLogsRequiresMember(t *testing.T) {
+func TestStreamWorkloadLogsRequiresViewWorkloads(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatalf("failed to create mock pool: %v", err)

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -417,7 +418,7 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.requireOrgMember(ctx, callerID, workload.OrganizationID); err != nil {
+	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
 		return nil, err
 	}
 	workloads, err := s.buildWorkloadProtos(ctx, []workloadRecord{workload})
@@ -854,30 +855,29 @@ func parseWorkloadSort(sort *runnersv1.ListWorkloadsSort) (workloadListSort, err
 
 func workloadSortColumn(field workloadSortField) string {
 	switch field {
-	case workloadSortAgent:
-		return "agent_id"
-	case workloadSortRunner:
-		return "runner_id"
 	case workloadSortStatus:
-		return "status"
+		return "workloads.status"
 	case workloadSortDuration:
-		return "created_at"
+		return "workloads.created_at"
 	case workloadSortStarted:
-		return "created_at"
+		return "workloads.created_at"
 	default:
-		return "created_at"
+		panic("invalid sort field")
 	}
 }
 
 func workloadCursorPrimary(field workloadSortField, cursor listCursor) (any, error) {
 	switch field {
 	case workloadSortAgent, workloadSortRunner:
-		id, err := uuid.Parse(cursor.Primary)
-		if err != nil {
-			return nil, fmt.Errorf("parse id: %w", err)
+		primary := strings.TrimSpace(cursor.Primary)
+		if primary == "" {
+			return nil, errors.New("cursor primary is empty")
 		}
-		return id, nil
+		return strings.ToLower(primary), nil
 	case workloadSortStatus:
+		if strings.TrimSpace(cursor.Primary) == "" {
+			return nil, errors.New("cursor primary is empty")
+		}
 		return cursor.Primary, nil
 	case workloadSortDuration, workloadSortStarted:
 		createdAt, err := time.Parse(time.RFC3339Nano, cursor.Primary)
@@ -890,12 +890,20 @@ func workloadCursorPrimary(field workloadSortField, cursor listCursor) (any, err
 	}
 }
 
-func workloadPrimaryValue(record workloadRecord, field workloadSortField) (string, error) {
+func workloadPrimaryValue(record workloadRecord, field workloadSortField, agentNames map[uuid.UUID]string, runnerNames map[uuid.UUID]string) (string, error) {
 	switch field {
 	case workloadSortAgent:
-		return record.AgentID.String(), nil
+		name, ok := agentNames[record.AgentID]
+		if !ok {
+			return "", fmt.Errorf("agent name missing for %s", record.AgentID)
+		}
+		return strings.ToLower(strings.TrimSpace(name)), nil
 	case workloadSortRunner:
-		return record.RunnerID.String(), nil
+		name, ok := runnerNames[record.RunnerID]
+		if !ok {
+			return "", fmt.Errorf("runner name missing for %s", record.RunnerID)
+		}
+		return strings.ToLower(strings.TrimSpace(name)), nil
 	case workloadSortStatus:
 		return record.Status, nil
 	case workloadSortDuration, workloadSortStarted:
@@ -910,38 +918,130 @@ func addCursorClause(clauses *[]string, args *[]any, column string, direction so
 	if direction == sortDesc {
 		operator = "<"
 	}
-	clause := fmt.Sprintf("(%s %s $%d OR (%s = $%d AND id > $%d))", column, operator, len(*args)+1, column, len(*args)+1, len(*args)+2)
+	clause := fmt.Sprintf("(%s %s $%d OR (%s = $%d AND workloads.id > $%d))", column, operator, len(*args)+1, column, len(*args)+1, len(*args)+2)
 	*clauses = append(*clauses, clause)
 	*args = append(*args, primary, id)
 }
 
+func (s *Server) listWorkloadAgentIDs(ctx context.Context, clauses []string, args []any) ([]uuid.UUID, error) {
+	query := strings.Builder{}
+	query.WriteString("SELECT DISTINCT agent_id FROM workloads")
+	if len(clauses) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(strings.Join(clauses, " AND "))
+	}
+	rows, err := s.pool.Query(ctx, query.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	agentIDs := []uuid.UUID{}
+	for rows.Next() {
+		var agentID uuid.UUID
+		if err := rows.Scan(&agentID); err != nil {
+			return nil, err
+		}
+		agentIDs = append(agentIDs, agentID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return agentIDs, nil
+}
+
+func buildWorkloadAgentSortExpr(agentNames map[uuid.UUID]string, startIndex int) (string, []any, error) {
+	if len(agentNames) == 0 {
+		return "", nil, errors.New("agent names empty")
+	}
+	ids := make([]uuid.UUID, 0, len(agentNames))
+	for id := range agentNames {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].String() < ids[j].String()
+	})
+
+	parts := make([]string, 0, len(ids))
+	args := make([]any, 0, len(ids)*2)
+	idx := startIndex
+	for _, id := range ids {
+		name := strings.ToLower(strings.TrimSpace(agentNames[id]))
+		parts = append(parts, fmt.Sprintf("WHEN $%d THEN $%d", idx, idx+1))
+		args = append(args, id, name)
+		idx += 2
+	}
+	return fmt.Sprintf("CASE workloads.agent_id %s END", strings.Join(parts, " ")), args, nil
+}
+
 func (s *Server) listWorkloads(ctx context.Context, filter workloadListFilter, sort workloadListSort, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
 	limit := normalizePageSize(pageSize)
-	clauses := []string{fmt.Sprintf("organization_id = $%d", 1)}
+	clauses := []string{fmt.Sprintf("workloads.organization_id = $%d", 1)}
 	args := []any{filter.OrganizationID}
 
 	if len(filter.AgentIDs) > 0 {
-		clauses = append(clauses, fmt.Sprintf("agent_id = ANY($%d)", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("workloads.agent_id = ANY($%d)", len(args)+1))
 		args = append(args, pgtype.FlatArray[uuid.UUID](filter.AgentIDs))
 	}
 	if len(filter.RunnerIDs) > 0 {
-		clauses = append(clauses, fmt.Sprintf("runner_id = ANY($%d)", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("workloads.runner_id = ANY($%d)", len(args)+1))
 		args = append(args, pgtype.FlatArray[uuid.UUID](filter.RunnerIDs))
 	}
 	if len(filter.Statuses) > 0 {
-		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("workloads.status = ANY($%d)", len(args)+1))
 		args = append(args, pgtype.FlatArray[string](filter.Statuses))
 	}
 	if filter.StartedAfter != nil {
-		clauses = append(clauses, fmt.Sprintf("created_at >= $%d", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("workloads.created_at >= $%d", len(args)+1))
 		args = append(args, *filter.StartedAfter)
 	}
 	if filter.StartedBefore != nil {
-		clauses = append(clauses, fmt.Sprintf("created_at < $%d", len(args)+1))
+		clauses = append(clauses, fmt.Sprintf("workloads.created_at < $%d", len(args)+1))
 		args = append(args, *filter.StartedBefore)
 	}
 	if filter.PendingSample {
 		clauses = append(clauses, pendingSampleClause)
+	}
+
+	var (
+		joinClause  string
+		sortColumn  string
+		agentNames  map[uuid.UUID]string
+		runnerNames map[uuid.UUID]string
+	)
+	switch sort.Field {
+	case workloadSortRunner:
+		joinClause = " JOIN runners ON workloads.runner_id = runners.id"
+		sortColumn = "LOWER(runners.name)"
+	case workloadSortAgent:
+		agentIDs, err := s.listWorkloadAgentIDs(ctx, clauses, args)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(agentIDs) == 0 {
+			if pageToken != "" {
+				cursor, _, err := decodeListCursor(pageToken)
+				if err != nil {
+					return nil, "", InvalidPageToken(err)
+				}
+				if _, err := workloadCursorPrimary(sort.Field, cursor); err != nil {
+					return nil, "", InvalidPageToken(err)
+				}
+			}
+			return []workloadRecord{}, "", nil
+		}
+		agentNames, err = s.resolveAgentNames(ctx, uniqueUUIDs(agentIDs))
+		if err != nil {
+			return nil, "", err
+		}
+		sortExpr, sortArgs, err := buildWorkloadAgentSortExpr(agentNames, len(args)+1)
+		if err != nil {
+			return nil, "", err
+		}
+		sortColumn = sortExpr
+		args = append(args, sortArgs...)
+	default:
+		sortColumn = workloadSortColumn(sort.Field)
 	}
 
 	if pageToken != "" {
@@ -953,16 +1053,17 @@ func (s *Server) listWorkloads(ctx context.Context, filter workloadListFilter, s
 		if err != nil {
 			return nil, "", InvalidPageToken(err)
 		}
-		addCursorClause(&clauses, &args, workloadSortColumn(sort.Field), sort.Direction, primaryValue, cursorID)
+		addCursorClause(&clauses, &args, sortColumn, sort.Direction, primaryValue, cursorID)
 	}
 
 	query := strings.Builder{}
 	query.WriteString(fmt.Sprintf("SELECT %s FROM workloads", workloadColumns))
+	query.WriteString(joinClause)
 	if len(clauses) > 0 {
 		query.WriteString(" WHERE ")
 		query.WriteString(strings.Join(clauses, " AND "))
 	}
-	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, id ASC LIMIT $%d", workloadSortColumn(sort.Field), sort.Direction, len(args)+1))
+	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, workloads.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1))
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)
@@ -994,7 +1095,15 @@ func (s *Server) listWorkloads(ctx context.Context, filter workloadListFilter, s
 
 	nextToken := ""
 	if hasMore {
-		primary, err := workloadPrimaryValue(lastRecord, sort.Field)
+		if sort.Field == workloadSortRunner {
+			runnerIDs := []uuid.UUID{lastRecord.RunnerID}
+			resolved, err := s.resolveRunnerNames(ctx, runnerIDs)
+			if err != nil {
+				return nil, "", err
+			}
+			runnerNames = resolved
+		}
+		primary, err := workloadPrimaryValue(lastRecord, sort.Field, agentNames, runnerNames)
 		if err != nil {
 			return nil, "", err
 		}

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -495,8 +495,14 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(organizationID)); err != nil {
+	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	if err != nil {
 		return nil, err
+	}
+	if !isClusterAdmin {
+		if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(organizationID)); err != nil {
+			return nil, err
+		}
 	}
 
 	filter := workloadListFilter{OrganizationID: organizationID}

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -457,25 +457,18 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 		}
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
 	}
-	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
-	if err != nil {
-		return nil, err
-	}
-	if !isClusterAdmin {
-		memberCache := map[uuid.UUID]bool{}
-		filtered := make([]workloadRecord, 0, len(workloads))
-		for _, workload := range workloads {
-			allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
-			if err != nil {
-				return nil, err
-			}
-			if allowed {
-				filtered = append(filtered, workload)
-			}
+	memberCache := map[uuid.UUID]bool{}
+	filtered := make([]workloadRecord, 0, len(workloads))
+	for _, workload := range workloads {
+		allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
+		if err != nil {
+			return nil, err
 		}
-		workloads = filtered
+		if allowed {
+			filtered = append(filtered, workload)
+		}
 	}
-	protoWorkloads, err := toProtoWorkloadList(workloads)
+	protoWorkloads, err := toProtoWorkloadList(filtered)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert workloads: %v", err)
 	}

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -495,14 +495,8 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
-	if err != nil {
+	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(organizationID)); err != nil {
 		return nil, err
-	}
-	if !isClusterAdmin {
-		if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(organizationID)); err != nil {
-			return nil, err
-		}
 	}
 
 	filter := workloadListFilter{OrganizationID: organizationID}

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -89,6 +89,31 @@ type workloadUpdateInput struct {
 	LastMeteringAt *time.Time
 }
 
+type workloadListFilter struct {
+	OrganizationID uuid.UUID
+	AgentIDs       []uuid.UUID
+	RunnerIDs      []uuid.UUID
+	Statuses       []string
+	StartedAfter   *time.Time
+	StartedBefore  *time.Time
+	PendingSample  bool
+}
+
+type workloadSortField int
+
+const (
+	workloadSortStarted workloadSortField = iota
+	workloadSortAgent
+	workloadSortRunner
+	workloadSortStatus
+	workloadSortDuration
+)
+
+type workloadListSort struct {
+	Field     workloadSortField
+	Direction sortDirection
+}
+
 type containerRecord struct {
 	ContainerID  string     `json:"container_id"`
 	Name         string     `json:"name"`
@@ -395,11 +420,11 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	if err := s.requireOrgMember(ctx, callerID, workload.OrganizationID); err != nil {
 		return nil, err
 	}
-	protoWorkload, err := toProtoWorkload(workload)
+	workloads, err := s.buildWorkloadProtos(ctx, []workloadRecord{workload})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert workload: %v", err)
 	}
-	return &runnersv1.GetWorkloadResponse{Workload: protoWorkload}, nil
+	return &runnersv1.GetWorkloadResponse{Workload: workloads[0]}, nil
 }
 
 func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListWorkloadsByThreadRequest) (*runnersv1.ListWorkloadsByThreadResponse, error) {
@@ -461,40 +486,85 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
 	}
-	statuses, err := workloadStatusesToStrings(req.GetStatuses())
+	orgValue := strings.TrimSpace(req.GetOrganizationId())
+	if orgValue == "" {
+		return nil, status.Error(codes.InvalidArgument, "organization_id: value is empty")
+	}
+	organizationID, err := parseUUID(orgValue)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	var organizationID *uuid.UUID
-	if req.OrganizationId != nil {
-		parsed, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(organizationID)); err != nil {
+		return nil, err
+	}
+
+	filter := workloadListFilter{OrganizationID: organizationID}
+	pendingSampleSet := false
+	if req.Filter != nil {
+		filter.AgentIDs = make([]uuid.UUID, 0, len(req.Filter.AgentIdIn))
+		for _, agentValue := range req.Filter.AgentIdIn {
+			parsed, err := parseUUID(agentValue)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "filter.agent_id_in: %v", err)
+			}
+			filter.AgentIDs = append(filter.AgentIDs, parsed)
 		}
-		organizationID = &parsed
+		filter.RunnerIDs = make([]uuid.UUID, 0, len(req.Filter.RunnerIdIn))
+		for _, runnerValue := range req.Filter.RunnerIdIn {
+			parsed, err := parseUUID(runnerValue)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "filter.runner_id_in: %v", err)
+			}
+			filter.RunnerIDs = append(filter.RunnerIDs, parsed)
+		}
+		if req.Filter.StartedAfter != nil {
+			if err := req.Filter.StartedAfter.CheckValid(); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "filter.started_after: %v", err)
+			}
+			startedAfter := req.Filter.StartedAfter.AsTime()
+			filter.StartedAfter = &startedAfter
+		}
+		if req.Filter.StartedBefore != nil {
+			if err := req.Filter.StartedBefore.CheckValid(); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "filter.started_before: %v", err)
+			}
+			startedBefore := req.Filter.StartedBefore.AsTime()
+			filter.StartedBefore = &startedBefore
+		}
+		if req.Filter.PendingSample != nil {
+			filter.PendingSample = req.Filter.GetPendingSample()
+			pendingSampleSet = true
+		}
 	}
-	var runnerID *uuid.UUID
+
 	if req.RunnerId != nil {
 		parsed, err := parseUUID(req.GetRunnerId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 		}
-		runnerID = &parsed
+		filter.RunnerIDs = append(filter.RunnerIDs, parsed)
+	}
+	if req.PendingSample != nil && !pendingSampleSet {
+		filter.PendingSample = req.GetPendingSample()
 	}
 
-	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	statusFilters := make([]runnersv1.WorkloadStatus, 0)
+	if req.Filter != nil {
+		statusFilters = append(statusFilters, req.Filter.StatusIn...)
+	}
+	statusFilters = append(statusFilters, req.GetStatuses()...)
+	statuses, err := workloadStatusesToStrings(statusFilters)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
 	}
-	if organizationID != nil && !isClusterAdmin {
-		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
-			return nil, err
-		}
+	filter.Statuses = statuses
+
+	sort, err := parseWorkloadSort(req.GetSort())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "sort: %v", err)
 	}
 
-	pendingSample := req.PendingSample != nil && req.GetPendingSample()
-
-	workloads, nextToken, err := s.listWorkloads(ctx, statuses, organizationID, runnerID, pendingSample, req.GetPageSize(), req.GetPageToken())
+	workloads, nextToken, err := s.listWorkloads(ctx, filter, sort, req.GetPageSize(), req.GetPageToken())
 	if err != nil {
 		var invalidToken *InvalidPageTokenError
 		if errors.As(err, &invalidToken) {
@@ -502,21 +572,7 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 		}
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
 	}
-	if organizationID == nil && !isClusterAdmin {
-		memberCache := map[uuid.UUID]bool{}
-		filtered := make([]workloadRecord, 0, len(workloads))
-		for _, workload := range workloads {
-			allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
-			if err != nil {
-				return nil, err
-			}
-			if allowed {
-				filtered = append(filtered, workload)
-			}
-		}
-		workloads = filtered
-	}
-	protoWorkloads, err := toProtoWorkloadList(workloads)
+	protoWorkloads, err := s.buildWorkloadProtos(ctx, workloads)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert workloads: %v", err)
 	}
@@ -762,23 +818,154 @@ func decodeWorkloadCursor(token string) (workloadCursor, error) {
 	return workloadCursor{CreatedAt: createdAt, ID: id}, nil
 }
 
-func (s *Server) listWorkloads(ctx context.Context, statuses []string, organizationID *uuid.UUID, runnerID *uuid.UUID, pendingSample bool, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
-	limit := normalizePageSize(pageSize)
-	query, args, err := buildListQuery(listQueryInput{
-		Table:          "workloads",
-		Columns:        workloadColumns,
-		Statuses:       statuses,
-		OrganizationID: organizationID,
-		RunnerID:       runnerID,
-		PendingSample:  pendingSample,
-		PageToken:      pageToken,
-		Limit:          limit,
-	})
+func parseWorkloadSort(sort *runnersv1.ListWorkloadsSort) (workloadListSort, error) {
+	field := workloadSortStarted
+	if sort != nil {
+		switch sort.GetField() {
+		case runnersv1.ListWorkloadsSortField_LIST_WORKLOADS_SORT_FIELD_UNSPECIFIED:
+			field = workloadSortStarted
+		case runnersv1.ListWorkloadsSortField_LIST_WORKLOADS_SORT_FIELD_STARTED:
+			field = workloadSortStarted
+		case runnersv1.ListWorkloadsSortField_LIST_WORKLOADS_SORT_FIELD_AGENT:
+			field = workloadSortAgent
+		case runnersv1.ListWorkloadsSortField_LIST_WORKLOADS_SORT_FIELD_RUNNER:
+			field = workloadSortRunner
+		case runnersv1.ListWorkloadsSortField_LIST_WORKLOADS_SORT_FIELD_STATUS:
+			field = workloadSortStatus
+		case runnersv1.ListWorkloadsSortField_LIST_WORKLOADS_SORT_FIELD_DURATION:
+			field = workloadSortDuration
+		default:
+			return workloadListSort{}, fmt.Errorf("invalid sort field: %s", sort.GetField().String())
+		}
+	}
+	defaultDirection := sortDesc
+	if sort == nil {
+		return workloadListSort{Field: field, Direction: defaultDirection}, nil
+	}
+	direction, err := parseSortDirection(sort.GetDirection(), defaultDirection)
 	if err != nil {
-		return nil, "", err
+		return workloadListSort{}, err
+	}
+	if field == workloadSortDuration {
+		direction = direction.invert()
+	}
+	return workloadListSort{Field: field, Direction: direction}, nil
+}
+
+func workloadSortColumn(field workloadSortField) string {
+	switch field {
+	case workloadSortAgent:
+		return "agent_id"
+	case workloadSortRunner:
+		return "runner_id"
+	case workloadSortStatus:
+		return "status"
+	case workloadSortDuration:
+		return "created_at"
+	case workloadSortStarted:
+		return "created_at"
+	default:
+		return "created_at"
+	}
+}
+
+func workloadCursorPrimary(field workloadSortField, cursor listCursor) (any, error) {
+	switch field {
+	case workloadSortAgent, workloadSortRunner:
+		id, err := uuid.Parse(cursor.Primary)
+		if err != nil {
+			return nil, fmt.Errorf("parse id: %w", err)
+		}
+		return id, nil
+	case workloadSortStatus:
+		return cursor.Primary, nil
+	case workloadSortDuration, workloadSortStarted:
+		createdAt, err := time.Parse(time.RFC3339Nano, cursor.Primary)
+		if err != nil {
+			return nil, fmt.Errorf("parse created_at: %w", err)
+		}
+		return createdAt, nil
+	default:
+		return nil, errors.New("invalid sort field")
+	}
+}
+
+func workloadPrimaryValue(record workloadRecord, field workloadSortField) (string, error) {
+	switch field {
+	case workloadSortAgent:
+		return record.AgentID.String(), nil
+	case workloadSortRunner:
+		return record.RunnerID.String(), nil
+	case workloadSortStatus:
+		return record.Status, nil
+	case workloadSortDuration, workloadSortStarted:
+		return record.Meta.CreatedAt.UTC().Format(time.RFC3339Nano), nil
+	default:
+		return "", errors.New("invalid sort field")
+	}
+}
+
+func addCursorClause(clauses *[]string, args *[]any, column string, direction sortDirection, primary any, id uuid.UUID) {
+	operator := ">"
+	if direction == sortDesc {
+		operator = "<"
+	}
+	clause := fmt.Sprintf("(%s %s $%d OR (%s = $%d AND id > $%d))", column, operator, len(*args)+1, column, len(*args)+1, len(*args)+2)
+	*clauses = append(*clauses, clause)
+	*args = append(*args, primary, id)
+}
+
+func (s *Server) listWorkloads(ctx context.Context, filter workloadListFilter, sort workloadListSort, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
+	limit := normalizePageSize(pageSize)
+	clauses := []string{fmt.Sprintf("organization_id = $%d", 1)}
+	args := []any{filter.OrganizationID}
+
+	if len(filter.AgentIDs) > 0 {
+		clauses = append(clauses, fmt.Sprintf("agent_id = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[uuid.UUID](filter.AgentIDs))
+	}
+	if len(filter.RunnerIDs) > 0 {
+		clauses = append(clauses, fmt.Sprintf("runner_id = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[uuid.UUID](filter.RunnerIDs))
+	}
+	if len(filter.Statuses) > 0 {
+		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
+		args = append(args, pgtype.FlatArray[string](filter.Statuses))
+	}
+	if filter.StartedAfter != nil {
+		clauses = append(clauses, fmt.Sprintf("created_at >= $%d", len(args)+1))
+		args = append(args, *filter.StartedAfter)
+	}
+	if filter.StartedBefore != nil {
+		clauses = append(clauses, fmt.Sprintf("created_at < $%d", len(args)+1))
+		args = append(args, *filter.StartedBefore)
+	}
+	if filter.PendingSample {
+		clauses = append(clauses, pendingSampleClause)
 	}
 
-	rows, err := s.pool.Query(ctx, query, args...)
+	if pageToken != "" {
+		cursor, cursorID, err := decodeListCursor(pageToken)
+		if err != nil {
+			return nil, "", InvalidPageToken(err)
+		}
+		primaryValue, err := workloadCursorPrimary(sort.Field, cursor)
+		if err != nil {
+			return nil, "", InvalidPageToken(err)
+		}
+		addCursorClause(&clauses, &args, workloadSortColumn(sort.Field), sort.Direction, primaryValue, cursorID)
+	}
+
+	query := strings.Builder{}
+	query.WriteString(fmt.Sprintf("SELECT %s FROM workloads", workloadColumns))
+	if len(clauses) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(strings.Join(clauses, " AND "))
+	}
+	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, id ASC LIMIT $%d", workloadSortColumn(sort.Field), sort.Direction, len(args)+1))
+	args = append(args, int(limit)+1)
+
+	rows, err := s.pool.Query(ctx, query.String(), args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -786,8 +973,8 @@ func (s *Server) listWorkloads(ctx context.Context, statuses []string, organizat
 
 	workloads := make([]workloadRecord, 0, limit)
 	var (
-		lastID  uuid.UUID
-		hasMore bool
+		lastRecord workloadRecord
+		hasMore    bool
 	)
 	for rows.Next() {
 		if int32(len(workloads)) == limit {
@@ -799,7 +986,7 @@ func (s *Server) listWorkloads(ctx context.Context, statuses []string, organizat
 			return nil, "", err
 		}
 		workloads = append(workloads, workload)
-		lastID = workload.Meta.ID
+		lastRecord = workload
 	}
 	if err := rows.Err(); err != nil {
 		return nil, "", err
@@ -807,9 +994,57 @@ func (s *Server) listWorkloads(ctx context.Context, statuses []string, organizat
 
 	nextToken := ""
 	if hasMore {
-		nextToken = encodePageToken(lastID)
+		primary, err := workloadPrimaryValue(lastRecord, sort.Field)
+		if err != nil {
+			return nil, "", err
+		}
+		nextToken, err = encodeListCursor(primary, lastRecord.Meta.ID)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 	return workloads, nextToken, nil
+}
+
+func (s *Server) buildWorkloadProtos(ctx context.Context, records []workloadRecord) ([]*runnersv1.Workload, error) {
+	if len(records) == 0 {
+		return []*runnersv1.Workload{}, nil
+	}
+	agentIDs := make([]uuid.UUID, 0, len(records))
+	runnerIDs := make([]uuid.UUID, 0, len(records))
+	for _, record := range records {
+		agentIDs = append(agentIDs, record.AgentID)
+		runnerIDs = append(runnerIDs, record.RunnerID)
+	}
+	uniqueAgents := uniqueUUIDs(agentIDs)
+	uniqueRunners := uniqueUUIDs(runnerIDs)
+
+	agentNames, err := s.resolveAgentNames(ctx, uniqueAgents)
+	if err != nil {
+		return nil, err
+	}
+	runnerNames, err := s.resolveRunnerNames(ctx, uniqueRunners)
+	if err != nil {
+		return nil, err
+	}
+
+	workloads := make([]*runnersv1.Workload, 0, len(records))
+	for _, record := range records {
+		agentName, ok := agentNames[record.AgentID]
+		if !ok {
+			return nil, fmt.Errorf("agent name missing for %s", record.AgentID)
+		}
+		runnerName, ok := runnerNames[record.RunnerID]
+		if !ok {
+			return nil, fmt.Errorf("runner name missing for %s", record.RunnerID)
+		}
+		workload, err := toProtoWorkloadWithNames(record, agentName, runnerName)
+		if err != nil {
+			return nil, err
+		}
+		workloads = append(workloads, workload)
+	}
+	return workloads, nil
 }
 
 func (s *Server) batchUpdateWorkloadSampledAt(ctx context.Context, entries []sampledAtEntry) error {
@@ -923,6 +1158,16 @@ func toProtoWorkload(record workloadRecord) (*runnersv1.Workload, error) {
 		protoWorkload.FailureMessage = record.FailureMessage
 	}
 	return protoWorkload, nil
+}
+
+func toProtoWorkloadWithNames(record workloadRecord, agentName, runnerName string) (*runnersv1.Workload, error) {
+	workload, err := toProtoWorkload(record)
+	if err != nil {
+		return nil, err
+	}
+	workload.AgentName = agentName
+	workload.RunnerName = runnerName
+	return workload, nil
 }
 
 func toProtoWorkloadList(records []workloadRecord) ([]*runnersv1.Workload, error) {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -98,7 +98,7 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			gotCheckReqs = append(gotCheckReqs, req)
-			allowed := req.GetTupleKey().GetRelation() != clusterAdminRelation
+			allowed := req.GetTupleKey().GetRelation() == organizationViewWorkloads
 			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 		},
 	}
@@ -122,20 +122,14 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	if resp.GetWorkloads()[0].GetRunnerName() != runnerName {
 		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkloads()[0].GetRunnerName())
 	}
-	if len(gotCheckReqs) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
 	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewWorkloads {
-		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
-		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	if gotCheckReqs[0].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -181,7 +175,7 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			gotCheckReqs = append(gotCheckReqs, req)
-			allowed := req.GetTupleKey().GetRelation() != clusterAdminRelation
+			allowed := req.GetTupleKey().GetRelation() == organizationViewWorkloads
 			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 		},
 	}
@@ -206,20 +200,14 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	if resp.GetWorkloads()[0].GetRunnerName() != runnerName {
 		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkloads()[0].GetRunnerName())
 	}
-	if len(gotCheckReqs) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
 	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewWorkloads {
-		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
-		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	if gotCheckReqs[0].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -559,90 +547,19 @@ func TestListWorkloadsRequiresViewWorkloads(t *testing.T) {
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
-	if len(gotCheckReqs) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
 	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewWorkloads {
-		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
-		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	if gotCheckReqs[0].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}
-}
-
-func TestListWorkloadsAllowsClusterAdmin(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	workloadID := uuid.New()
-	runnerID := uuid.New()
-	threadID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-	containersJSON := []byte("[]")
-
-	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $2", workloadColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(organizationID, 51).
-		WillReturnRows(rows)
-
-	runnerName := "runner-name"
-	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
-	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
-		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
-		WillReturnRows(runnerRows)
-
-	agentName := "agent-name"
-	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
-		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
-	}}
-
-	var gotCheckReqs []*authorizationv1.CheckRequest
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReqs = append(gotCheckReqs, req)
-			allowed := req.GetTupleKey().GetRelation() == clusterAdminRelation
-			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
-	organizationIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
-	if err != nil {
-		t.Fatalf("ListWorkloads failed: %v", err)
-	}
-	if len(resp.GetWorkloads()) != 1 {
-		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
-	}
-	if len(gotCheckReqs) != 1 {
-		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
-	}
-	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
-		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
-	}
-	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
-		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
-	}
-
 	if err := mockPool.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
@@ -75,12 +76,23 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	rows := pgxmock.NewRows(workloadRowColumns).
 		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY created_at DESC, id ASC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
 
-	checkRelations := make([]string, 0, 2)
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			relation := req.GetTupleKey().GetRelation()
@@ -103,7 +115,7 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 		},
 	}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
 	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
@@ -116,125 +128,17 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	if resp.GetWorkloads()[0].GetOrganizationId() != organizationID.String() {
 		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetWorkloads()[0].GetOrganizationId())
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	if resp.GetWorkloads()[0].GetAgentName() != agentName {
+		t.Fatalf("expected agent name %q, got %q", agentName, resp.GetWorkloads()[0].GetAgentName())
 	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if resp.GetWorkloads()[0].GetRunnerName() != runnerName {
+		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkloads()[0].GetRunnerName())
 	}
-
-	if err := mockPool.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
-}
-
-func TestListWorkloadsAllowsClusterAdminForOrganization(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	workloadID := uuid.New()
-	runnerID := uuid.New()
-	threadID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-	containersJSON := []byte("[]")
-
-	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(organizationID, 51).
-		WillReturnRows(rows)
-
-	checkRelations := make([]string, 0, 1)
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			if relation != clusterAdminRelation {
-				t.Fatalf("expected cluster admin relation, got %s", relation)
-			}
-			if req.GetTupleKey().GetObject() != clusterObject {
-				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-			}
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
-	organizationIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
-	if err != nil {
-		t.Fatalf("ListWorkloads failed: %v", err)
-	}
-	if len(resp.GetWorkloads()) != 1 {
-		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
-	}
-	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
-		t.Fatalf("expected cluster admin check, got %v", checkRelations)
-	}
-
-	if err := mockPool.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestListWorkloadsAllowsClusterAdminWithoutOrganization(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	workloadID := uuid.New()
-	runnerID := uuid.New()
-	threadID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-	containersJSON := []byte("[]")
-
-	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(runnerID, 51).
-		WillReturnRows(rows)
-
-	checkRelations := make([]string, 0, 1)
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			if relation != clusterAdminRelation {
-				t.Fatalf("expected cluster admin relation, got %s", relation)
-			}
-			if req.GetTupleKey().GetObject() != clusterObject {
-				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-			}
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
-	runnerIDValue := runnerID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{RunnerId: &runnerIDValue})
-	if err != nil {
-		t.Fatalf("ListWorkloads failed: %v", err)
-	}
-	if len(resp.GetWorkloads()) != 1 {
-		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
-	}
-	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
-		t.Fatalf("expected cluster admin check, got %v", checkRelations)
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -260,12 +164,23 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	rows := pgxmock.NewRows(workloadRowColumns).
 		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 AND runner_id = ANY($2) ORDER BY created_at DESC, id ASC LIMIT $3", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(runnerID, 51).
+		WithArgs(organizationID, pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID}), 51).
 		WillReturnRows(rows)
 
-	checkRelations := make([]string, 0, 2)
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			relation := req.GetTupleKey().GetRelation()
@@ -288,10 +203,11 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 		},
 	}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	runnerIDValue := runnerID.String()
+	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{RunnerId: &runnerIDValue})
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, RunnerId: &runnerIDValue})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
@@ -301,11 +217,14 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	if resp.GetWorkloads()[0].GetRunnerId() != runnerID.String() {
 		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetWorkloads()[0].GetRunnerId())
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	if resp.GetWorkloads()[0].GetAgentName() != agentName {
+		t.Fatalf("expected agent name %q, got %q", agentName, resp.GetWorkloads()[0].GetAgentName())
 	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if resp.GetWorkloads()[0].GetRunnerName() != runnerName {
+		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkloads()[0].GetRunnerName())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -331,12 +250,23 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	rows := pgxmock.NewRows(workloadRowColumns).
 		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE %s ORDER BY id ASC LIMIT $1", workloadColumns, pendingSampleClause)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 AND %s ORDER BY created_at DESC, id ASC LIMIT $2", workloadColumns, pendingSampleClause)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(51).
+		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
 
-	checkRelations := make([]string, 0, 2)
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
 			relation := req.GetTupleKey().GetRelation()
@@ -359,10 +289,11 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 		},
 	}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	pendingSample := true
+	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{PendingSample: &pendingSample})
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, PendingSample: &pendingSample})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
@@ -381,9 +312,69 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	}
 }
 
+func TestListWorkloadsCursorPagination(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	cursorTime := now.Add(-5 * time.Minute)
+	cursorID := uuid.New()
+	primary := cursorTime.Format(time.RFC3339Nano)
+	pageToken, err := encodeListCursor(primary, cursorID)
+	if err != nil {
+		t.Fatalf("encode cursor: %v", err)
+	}
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	pageSize := int32(2)
+	limit := normalizePageSize(pageSize)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 AND (created_at < $2 OR (created_at = $2 AND id > $3)) ORDER BY created_at DESC, id ASC LIMIT $4", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, cursorTime, cursorID, int(limit)+1).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	filter := workloadListFilter{OrganizationID: organizationID}
+	sort, err := parseWorkloadSort(nil)
+	if err != nil {
+		t.Fatalf("parse sort: %v", err)
+	}
+	workloads, nextToken, err := srv.listWorkloads(context.Background(), filter, sort, pageSize, pageToken)
+	if err != nil {
+		t.Fatalf("listWorkloads failed: %v", err)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(workloads))
+	}
+	if nextToken != "" {
+		t.Fatalf("expected empty next token, got %q", nextToken)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestListWorkloadsInvalidUUID(t *testing.T) {
-	srv := New(Options{})
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+	srv := New(Options{AuthorizationClient: authorizationClient})
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, uuid.NewString()))
+	organizationIDValue := uuid.NewString()
 
 	cases := []struct {
 		name string
@@ -400,7 +391,7 @@ func TestListWorkloadsInvalidUUID(t *testing.T) {
 			name: "runner_id",
 			req: func() *runnersv1.ListWorkloadsRequest {
 				value := "not-a-uuid"
-				return &runnersv1.ListWorkloadsRequest{RunnerId: &value}
+				return &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, RunnerId: &value}
 			}(),
 		},
 	}

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -76,7 +77,7 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	rows := pgxmock.NewRows(workloadRowColumns).
 		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY created_at DESC, id ASC LIMIT $2", workloadColumns)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
@@ -164,7 +165,7 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	rows := pgxmock.NewRows(workloadRowColumns).
 		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 AND runner_id = ANY($2) ORDER BY created_at DESC, id ASC LIMIT $3", workloadColumns)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND workloads.runner_id = ANY($2) ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $3", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID}), 51).
 		WillReturnRows(rows)
@@ -250,7 +251,7 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	rows := pgxmock.NewRows(workloadRowColumns).
 		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 AND %s ORDER BY created_at DESC, id ASC LIMIT $2", workloadColumns, pendingSampleClause)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND %s ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $2", workloadColumns, pendingSampleClause)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
@@ -339,7 +340,7 @@ func TestListWorkloadsCursorPagination(t *testing.T) {
 
 	pageSize := int32(2)
 	limit := normalizePageSize(pageSize)
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 AND (created_at < $2 OR (created_at = $2 AND id > $3)) ORDER BY created_at DESC, id ASC LIMIT $4", workloadColumns)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND (workloads.created_at < $2 OR (workloads.created_at = $2 AND workloads.id > $3)) ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $4", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, cursorTime, cursorID, int(limit)+1).
 		WillReturnRows(rows)
@@ -406,6 +407,29 @@ func TestListWorkloadsInvalidUUID(t *testing.T) {
 	}
 }
 
+func TestListWorkloadsInvalidPageToken(t *testing.T) {
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+	srv := New(Options{AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, uuid.NewString()))
+	organizationIDValue := uuid.NewString()
+	validID := uuid.NewString()
+
+	invalidJSONToken := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+	wrongPrimaryToken := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"primary":10,"id":"%s"}`, validID)))
+
+	cases := []string{"not-a-token", invalidJSONToken, wrongPrimaryToken}
+	for _, token := range cases {
+		_, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, PageToken: token})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument error for token %q, got %v", token, err)
+		}
+	}
+}
+
 func TestListWorkloadsRequiresMember(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
@@ -415,20 +439,11 @@ func TestListWorkloadsRequiresMember(t *testing.T) {
 	organizationID := uuid.New()
 	callerID := uuid.New()
 
-	checkRelations := make([]string, 0, 2)
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
 
@@ -439,11 +454,11 @@ func TestListWorkloadsRequiresMember(t *testing.T) {
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -681,8 +696,10 @@ func TestGetWorkloadRequiresMember(t *testing.T) {
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
 
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReq = req
 			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
@@ -692,6 +709,12 @@ func TestGetWorkloadRequiresMember(t *testing.T) {
 	_, err = srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -94,26 +94,12 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
 	}}
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	var gotCheckReqs []*authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				if req.GetTupleKey().GetObject() != clusterObject {
-					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
-					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: true}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReqs = append(gotCheckReqs, req)
+			allowed := req.GetTupleKey().GetRelation() != clusterAdminRelation
+			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 		},
 	}
 
@@ -136,11 +122,20 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	if resp.GetWorkloads()[0].GetRunnerName() != runnerName {
 		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkloads()[0].GetRunnerName())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(gotCheckReqs) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
-		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -182,26 +177,12 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
 	}}
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	var gotCheckReqs []*authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				if req.GetTupleKey().GetObject() != clusterObject {
-					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
-					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: true}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReqs = append(gotCheckReqs, req)
+			allowed := req.GetTupleKey().GetRelation() != clusterAdminRelation
+			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 		},
 	}
 
@@ -225,8 +206,20 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	if resp.GetWorkloads()[0].GetRunnerName() != runnerName {
 		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkloads()[0].GetRunnerName())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(gotCheckReqs) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
+	}
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -551,10 +544,10 @@ func TestListWorkloadsRequiresViewWorkloads(t *testing.T) {
 	organizationID := uuid.New()
 	callerID := uuid.New()
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	var gotCheckReqs []*authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
+			gotCheckReqs = append(gotCheckReqs, req)
 			return &authorizationv1.CheckResponse{Allowed: false}, nil
 		},
 	}
@@ -566,11 +559,88 @@ func TestListWorkloadsRequiresViewWorkloads(t *testing.T) {
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(gotCheckReqs) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(gotCheckReqs))
 	}
-	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
-		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[1].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[1].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[1].GetTupleKey().GetObject())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsAllowsClusterAdmin(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, 51).
+		WillReturnRows(rows)
+
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	var gotCheckReqs []*authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReqs = append(gotCheckReqs, req)
+			allowed := req.GetTupleKey().GetRelation() == clusterAdminRelation
+			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
+	}
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != clusterAdminRelation {
+		t.Fatalf("expected cluster admin relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %q, got %q", clusterObject, gotCheckReqs[0].GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -367,6 +368,117 @@ func TestListWorkloadsCursorPagination(t *testing.T) {
 	}
 }
 
+func TestListWorkloadsSortByAgentQuery(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	agentRows := pgxmock.NewRows([]string{"agent_id"}).AddRow(agentID)
+	agentQuery := "SELECT DISTINCT agent_id FROM workloads WHERE workloads.organization_id = $1"
+	mockPool.ExpectQuery(regexp.QuoteMeta(agentQuery)).WithArgs(organizationID).WillReturnRows(agentRows)
+
+	agentName := "Agent Alpha"
+	primary := strings.ToLower(agentName)
+	cursorID := uuid.New()
+	pageToken, err := encodeListCursor(primary, cursorID)
+	if err != nil {
+		t.Fatalf("encode cursor: %v", err)
+	}
+
+	pageSize := int32(1)
+	limit := normalizePageSize(pageSize)
+	sortExpr := "CASE workloads.agent_id WHEN $2 THEN $3 END"
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND (%s > $4 OR (%s = $4 AND workloads.id > $5)) ORDER BY %s ASC, workloads.id ASC LIMIT $6", workloadColumns, sortExpr, sortExpr, sortExpr)
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, agentID, primary, primary, cursorID, int(limit)+1).
+		WillReturnRows(rows)
+
+	agentsClient := fakeAgentsClient{
+		getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AgentsClient: agentsClient})
+	filter := workloadListFilter{OrganizationID: organizationID}
+	sort := workloadListSort{Field: workloadSortAgent, Direction: sortAsc}
+	workloads, nextToken, err := srv.listWorkloads(context.Background(), filter, sort, pageSize, pageToken)
+	if err != nil {
+		t.Fatalf("listWorkloads failed: %v", err)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(workloads))
+	}
+	if nextToken != "" {
+		t.Fatalf("expected empty next token, got %q", nextToken)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsSortByRunnerQuery(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	primary := "runner-omega"
+	cursorID := uuid.New()
+	pageToken, err := encodeListCursor(primary, cursorID)
+	if err != nil {
+		t.Fatalf("encode cursor: %v", err)
+	}
+
+	pageSize := int32(1)
+	limit := normalizePageSize(pageSize)
+	sortColumn := "LOWER(runners.name)"
+	query := fmt.Sprintf("SELECT %s FROM workloads JOIN runners ON workloads.runner_id = runners.id WHERE workloads.organization_id = $1 AND (%s < $2 OR (%s = $2 AND workloads.id > $3)) ORDER BY %s DESC, workloads.id ASC LIMIT $4", workloadColumns, sortColumn, sortColumn, sortColumn)
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, primary, cursorID, int(limit)+1).
+		WillReturnRows(rows)
+
+	srv := New(Options{Pool: mockPool})
+	filter := workloadListFilter{OrganizationID: organizationID}
+	sort := workloadListSort{Field: workloadSortRunner, Direction: sortDesc}
+	workloads, nextToken, err := srv.listWorkloads(context.Background(), filter, sort, pageSize, pageToken)
+	if err != nil {
+		t.Fatalf("listWorkloads failed: %v", err)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(workloads))
+	}
+	if nextToken != "" {
+		t.Fatalf("expected empty next token, got %q", nextToken)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestListWorkloadsInvalidUUID(t *testing.T) {
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
@@ -430,7 +542,7 @@ func TestListWorkloadsInvalidPageToken(t *testing.T) {
 	}
 }
 
-func TestListWorkloadsRequiresMember(t *testing.T) {
+func TestListWorkloadsRequiresViewWorkloads(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatalf("failed to create mock pool: %v", err)
@@ -675,7 +787,7 @@ func TestListWorkloadsByThreadInvalidPageToken(t *testing.T) {
 	}
 }
 
-func TestGetWorkloadRequiresMember(t *testing.T) {
+func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatalf("failed to create mock pool: %v", err)

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -252,23 +252,8 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			switch relation {
-			case clusterAdminRelation:
-				if req.GetTupleKey().GetObject() != clusterObject {
-					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: false}, nil
-			case organizationMemberRelation:
-				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
-					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
-				}
-				return &authorizationv1.CheckResponse{Allowed: true}, nil
-			default:
-				t.Fatalf("unexpected relation %s", relation)
-				return nil, status.Error(codes.Internal, "unexpected relation")
-			}
+			gotCheckReq = req
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
 		},
 	}
 
@@ -283,11 +268,8 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	if len(resp.GetWorkloads()) != 1 {
 		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
 	}
-	if len(checkRelations) != 2 {
-		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
-	}
-	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
-		t.Fatalf("unexpected relation order %v", checkRelations)
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -600,62 +582,6 @@ func TestListWorkloadsByThreadFilters(t *testing.T) {
 	}
 	if nextToken != "" {
 		t.Fatalf("expected empty next token, got %q", nextToken)
-	}
-
-	if err := mockPool.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
-	}
-}
-
-func TestListWorkloadsByThreadAllowsClusterAdmin(t *testing.T) {
-	mockPool, err := pgxmock.NewPool()
-	if err != nil {
-		t.Fatalf("failed to create mock pool: %v", err)
-	}
-
-	workloadID := uuid.New()
-	runnerID := uuid.New()
-	threadID := uuid.New()
-	agentID := uuid.New()
-	organizationID := uuid.New()
-	callerID := uuid.New()
-	now := time.Now().UTC()
-	containersJSON := []byte("[]")
-
-	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
-
-	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 ORDER BY created_at DESC, id DESC LIMIT $2", workloadColumns)
-	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(threadID, 51).
-		WillReturnRows(rows)
-
-	checkRelations := make([]string, 0, 1)
-	authorizationClient := fakeAuthorizationClient{
-		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			relation := req.GetTupleKey().GetRelation()
-			checkRelations = append(checkRelations, relation)
-			if relation != clusterAdminRelation {
-				t.Fatalf("expected cluster admin relation, got %s", relation)
-			}
-			if req.GetTupleKey().GetObject() != clusterObject {
-				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
-			}
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{ThreadId: threadID.String()})
-	if err != nil {
-		t.Fatalf("ListWorkloadsByThread failed: %v", err)
-	}
-	if len(resp.GetWorkloads()) != 1 {
-		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
-	}
-	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
-		t.Fatalf("expected cluster admin check, got %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- add agents client wiring and name resolution for workloads/volumes
- implement list filters/sort/cursor pagination and volume enrichment
- publish volume.updated notifications and expand list coverage tests

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/notifications/v1
- go vet ./...
- go test ./...

Refs #40