### PR TITLE
fix(authz): allow cluster-admin list

### DIFF
--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -27,6 +27,10 @@ func (s *Server) requireClusterAdmin(ctx context.Context, identityID uuid.UUID) 
 	return s.requireRelation(ctx, identityID, clusterAdminRelation, clusterObject)
 }
 
+func (s *Server) clusterAdminAllowed(ctx context.Context, identityID uuid.UUID) (bool, error) {
+	return s.relationAllowed(ctx, identityID, clusterAdminRelation, clusterObject)
+}
+
 func (s *Server) requireOrgOwner(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
 	return s.requireRelation(ctx, identityID, organizationOwnerRelation, organizationObject(organizationID))
 }

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -218,18 +218,25 @@ func (s *Server) ListVolumesByThread(ctx context.Context, req *runnersv1.ListVol
 		}
 		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
 	}
-	memberCache := map[uuid.UUID]bool{}
-	filtered := make([]volumeRecord, 0, len(volumes))
-	for _, volume := range volumes {
-		allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
-		if err != nil {
-			return nil, err
-		}
-		if allowed {
-			filtered = append(filtered, volume)
-		}
+	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	if err != nil {
+		return nil, err
 	}
-	protoVolumes, err := toProtoVolumeList(filtered)
+	if !isClusterAdmin {
+		memberCache := map[uuid.UUID]bool{}
+		filtered := make([]volumeRecord, 0, len(volumes))
+		for _, volume := range volumes {
+			allowed, err := s.memberAllowed(ctx, callerID, volume.OrganizationID, memberCache)
+			if err != nil {
+				return nil, err
+			}
+			if allowed {
+				filtered = append(filtered, volume)
+			}
+		}
+		volumes = filtered
+	}
+	protoVolumes, err := toProtoVolumeList(volumes)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert volumes: %v", err)
 	}
@@ -253,12 +260,6 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 		}
 		organizationID = &parsed
 	}
-	if organizationID != nil {
-		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
-			return nil, err
-		}
-	}
-
 	var runnerID *uuid.UUID
 	if req.RunnerId != nil {
 		parsed, err := parseUUID(req.GetRunnerId())
@@ -266,6 +267,16 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 		}
 		runnerID = &parsed
+	}
+
+	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	if err != nil {
+		return nil, err
+	}
+	if organizationID != nil && !isClusterAdmin {
+		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
+			return nil, err
+		}
 	}
 
 	pendingSample := req.PendingSample != nil && req.GetPendingSample()
@@ -278,7 +289,7 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 		}
 		return nil, status.Errorf(codes.Internal, "list volumes: %v", err)
 	}
-	if organizationID == nil {
+	if organizationID == nil && !isClusterAdmin {
 		memberCache := map[uuid.UUID]bool{}
 		filtered := make([]volumeRecord, 0, len(volumes))
 		for _, volume := range volumes {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -56,11 +56,26 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				if req.GetTupleKey().GetObject() != clusterObject {
+					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
+					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: true}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -77,8 +92,125 @@ func TestListVolumesFiltersOrganization(t *testing.T) {
 	if resp.GetVolumes()[0].GetOrganizationId() != organizationID.String() {
 		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetVolumes()[0].GetOrganizationId())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListVolumesAllowsClusterAdminForOrganization(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, 51).
+		WillReturnRows(rows)
+
+	checkRelations := make([]string, 0, 1)
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			if relation != clusterAdminRelation {
+				t.Fatalf("expected cluster admin relation, got %s", relation)
+			}
+			if req.GetTupleKey().GetObject() != clusterObject {
+				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
+	if err != nil {
+		t.Fatalf("ListVolumes failed: %v", err)
+	}
+	if len(resp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
+		t.Fatalf("expected cluster admin check, got %v", checkRelations)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListVolumesAllowsClusterAdminWithoutOrganization(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(runnerID, 51).
+		WillReturnRows(rows)
+
+	checkRelations := make([]string, 0, 1)
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			if relation != clusterAdminRelation {
+				t.Fatalf("expected cluster admin relation, got %s", relation)
+			}
+			if req.GetTupleKey().GetObject() != clusterObject {
+				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	runnerIDValue := runnerID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{RunnerId: &runnerIDValue})
+	if err != nil {
+		t.Fatalf("ListVolumes failed: %v", err)
+	}
+	if len(resp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
+		t.Fatalf("expected cluster admin check, got %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -109,11 +241,26 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 		WithArgs(runnerID, 51).
 		WillReturnRows(rows)
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				if req.GetTupleKey().GetObject() != clusterObject {
+					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
+					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: true}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -130,8 +277,67 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	if resp.GetVolumes()[0].GetRunnerId() != runnerID.String() {
 		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetVolumes()[0].GetRunnerId())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListVolumesByThreadAllowsClusterAdmin(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	volumeID := uuid.New()
+	volumeResourceID := uuid.New()
+	threadID := uuid.New()
+	runnerID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+
+	rows := pgxmock.NewRows(volumeRowColumns).
+		AddRow(volumeID, nil, volumeResourceID, threadID, runnerID, agentID, organizationID, "10", volumeStatusActive, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM volumes WHERE thread_id = $1 ORDER BY id ASC LIMIT $2", volumeColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(threadID, 51).
+		WillReturnRows(rows)
+
+	checkRelations := make([]string, 0, 1)
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			if relation != clusterAdminRelation {
+				t.Fatalf("expected cluster admin relation, got %s", relation)
+			}
+			if req.GetTupleKey().GetObject() != clusterObject {
+				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListVolumesByThread(ctx, &runnersv1.ListVolumesByThreadRequest{ThreadId: threadID.String()})
+	if err != nil {
+		t.Fatalf("ListVolumesByThread failed: %v", err)
+	}
+	if len(resp.GetVolumes()) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
+	}
+	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
+		t.Fatalf("expected cluster admin check, got %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -162,11 +368,26 @@ func TestListVolumesPendingSample(t *testing.T) {
 		WithArgs(51).
 		WillReturnRows(rows)
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				if req.GetTupleKey().GetObject() != clusterObject {
+					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
+					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: true}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -180,8 +401,11 @@ func TestListVolumesPendingSample(t *testing.T) {
 	if len(resp.GetVolumes()) != 1 {
 		t.Fatalf("expected 1 volume, got %d", len(resp.GetVolumes()))
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -232,9 +456,20 @@ func TestListVolumesRequiresMember(t *testing.T) {
 	organizationID := uuid.New()
 	callerID := uuid.New()
 
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			return &authorizationv1.CheckResponse{Allowed: false}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -244,6 +479,12 @@ func TestListVolumesRequiresMember(t *testing.T) {
 	_, err = srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue})
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -431,18 +431,25 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 		}
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
 	}
-	memberCache := map[uuid.UUID]bool{}
-	filtered := make([]workloadRecord, 0, len(workloads))
-	for _, workload := range workloads {
-		allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
-		if err != nil {
-			return nil, err
-		}
-		if allowed {
-			filtered = append(filtered, workload)
-		}
+	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	if err != nil {
+		return nil, err
 	}
-	protoWorkloads, err := toProtoWorkloadList(filtered)
+	if !isClusterAdmin {
+		memberCache := map[uuid.UUID]bool{}
+		filtered := make([]workloadRecord, 0, len(workloads))
+		for _, workload := range workloads {
+			allowed, err := s.memberAllowed(ctx, callerID, workload.OrganizationID, memberCache)
+			if err != nil {
+				return nil, err
+			}
+			if allowed {
+				filtered = append(filtered, workload)
+			}
+		}
+		workloads = filtered
+	}
+	protoWorkloads, err := toProtoWorkloadList(workloads)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert workloads: %v", err)
 	}
@@ -466,12 +473,6 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 		}
 		organizationID = &parsed
 	}
-	if organizationID != nil {
-		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
-			return nil, err
-		}
-	}
-
 	var runnerID *uuid.UUID
 	if req.RunnerId != nil {
 		parsed, err := parseUUID(req.GetRunnerId())
@@ -479,6 +480,16 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 		}
 		runnerID = &parsed
+	}
+
+	isClusterAdmin, err := s.clusterAdminAllowed(ctx, callerID)
+	if err != nil {
+		return nil, err
+	}
+	if organizationID != nil && !isClusterAdmin {
+		if err := s.requireOrgMember(ctx, callerID, *organizationID); err != nil {
+			return nil, err
+		}
 	}
 
 	pendingSample := req.PendingSample != nil && req.GetPendingSample()
@@ -491,7 +502,7 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 		}
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
 	}
-	if organizationID == nil {
+	if organizationID == nil && !isClusterAdmin {
 		memberCache := map[uuid.UUID]bool{}
 		filtered := make([]workloadRecord, 0, len(workloads))
 		for _, workload := range workloads {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -80,11 +80,26 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 		WithArgs(organizationID, 51).
 		WillReturnRows(rows)
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				if req.GetTupleKey().GetObject() != clusterObject {
+					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
+					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: true}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -101,11 +116,125 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	if resp.GetWorkloads()[0].GetOrganizationId() != organizationID.String() {
 		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetWorkloads()[0].GetOrganizationId())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
 	}
-	if gotCheckReq.GetTupleKey().GetRelation() != organizationMemberRelation {
-		t.Fatalf("expected member relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsAllowsClusterAdminForOrganization(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE organization_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(organizationID, 51).
+		WillReturnRows(rows)
+
+	checkRelations := make([]string, 0, 1)
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			if relation != clusterAdminRelation {
+				t.Fatalf("expected cluster admin relation, got %s", relation)
+			}
+			if req.GetTupleKey().GetObject() != clusterObject {
+				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	organizationIDValue := organizationID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
+		t.Fatalf("expected cluster admin check, got %v", checkRelations)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsAllowsClusterAdminWithoutOrganization(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE runner_id = $1 ORDER BY id ASC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(runnerID, 51).
+		WillReturnRows(rows)
+
+	checkRelations := make([]string, 0, 1)
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			if relation != clusterAdminRelation {
+				t.Fatalf("expected cluster admin relation, got %s", relation)
+			}
+			if req.GetTupleKey().GetObject() != clusterObject {
+				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	runnerIDValue := runnerID.String()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{RunnerId: &runnerIDValue})
+	if err != nil {
+		t.Fatalf("ListWorkloads failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
+		t.Fatalf("expected cluster admin check, got %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -136,11 +265,26 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 		WithArgs(runnerID, 51).
 		WillReturnRows(rows)
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				if req.GetTupleKey().GetObject() != clusterObject {
+					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
+					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: true}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -157,8 +301,11 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	if resp.GetWorkloads()[0].GetRunnerId() != runnerID.String() {
 		t.Fatalf("expected runner id %q, got %q", runnerID.String(), resp.GetWorkloads()[0].GetRunnerId())
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -189,11 +336,26 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 		WithArgs(51).
 		WillReturnRows(rows)
 
-	var gotCheckReq *authorizationv1.CheckRequest
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			gotCheckReq = req
-			return &authorizationv1.CheckResponse{Allowed: true}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				if req.GetTupleKey().GetObject() != clusterObject {
+					t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				if req.GetTupleKey().GetObject() != organizationObject(organizationID) {
+					t.Fatalf("expected organization object %s, got %s", organizationObject(organizationID), req.GetTupleKey().GetObject())
+				}
+				return &authorizationv1.CheckResponse{Allowed: true}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -207,8 +369,11 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	if len(resp.GetWorkloads()) != 1 {
 		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
 	}
-	if gotCheckReq == nil {
-		t.Fatal("expected authorization Check to be called")
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -259,9 +424,20 @@ func TestListWorkloadsRequiresMember(t *testing.T) {
 	organizationID := uuid.New()
 	callerID := uuid.New()
 
+	checkRelations := make([]string, 0, 2)
 	authorizationClient := fakeAuthorizationClient{
 		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
-			return &authorizationv1.CheckResponse{Allowed: false}, nil
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			switch relation {
+			case clusterAdminRelation:
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			case organizationMemberRelation:
+				return &authorizationv1.CheckResponse{Allowed: false}, nil
+			default:
+				t.Fatalf("unexpected relation %s", relation)
+				return nil, status.Error(codes.Internal, "unexpected relation")
+			}
 		},
 	}
 
@@ -271,6 +447,12 @@ func TestListWorkloadsRequiresMember(t *testing.T) {
 	_, err = srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue})
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if len(checkRelations) != 2 {
+		t.Fatalf("expected 2 authorization checks, got %d", len(checkRelations))
+	}
+	if checkRelations[0] != clusterAdminRelation || checkRelations[1] != organizationMemberRelation {
+		t.Fatalf("unexpected relation order %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -313,6 +495,62 @@ func TestListWorkloadsByThreadFilters(t *testing.T) {
 	}
 	if nextToken != "" {
 		t.Fatalf("expected empty next token, got %q", nextToken)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListWorkloadsByThreadAllowsClusterAdmin(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 ORDER BY created_at DESC, id DESC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(threadID, 51).
+		WillReturnRows(rows)
+
+	checkRelations := make([]string, 0, 1)
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			relation := req.GetTupleKey().GetRelation()
+			checkRelations = append(checkRelations, relation)
+			if relation != clusterAdminRelation {
+				t.Fatalf("expected cluster admin relation, got %s", relation)
+			}
+			if req.GetTupleKey().GetObject() != clusterObject {
+				t.Fatalf("expected cluster object %s, got %s", clusterObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{ThreadId: threadID.String()})
+	if err != nil {
+		t.Fatalf("ListWorkloadsByThread failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if len(checkRelations) != 1 || checkRelations[0] != clusterAdminRelation {
+		t.Fatalf("expected cluster admin check, got %v", checkRelations)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- allow cluster-admin identities to list workloads/volumes without org membership filtering
- permit organization-scoped list requests for cluster-admin callers
- cover cluster-admin list access in workloads/volumes tests

## Testing
- go test ./...
- go vet ./...
- go build ./...
- docker build -t runners-test .

Refs agynio/bootstrap#459