### PR TITLE
feat(runners): add workload agent_state

### DIFF
--- a/cmd/runners/main.go
+++ b/cmd/runners/main.go
@@ -93,7 +93,7 @@ func run() error {
 	defer notificationsConn.Close()
 
 	grpcServer := grpc.NewServer()
-	runnersv1.RegisterRunnersServiceServer(grpcServer, server.New(server.Options{
+	srv := server.New(server.Options{
 		Pool:                 pool,
 		IdentityClient:       identityv1.NewIdentityServiceClient(identityConn),
 		AuthorizationClient:  authorizationv1.NewAuthorizationServiceClient(authorizationConn),
@@ -101,7 +101,9 @@ func run() error {
 		ZitiManagementClient: zitiMgmtClient,
 		NotificationsClient:  notificationsv1.NewNotificationsServiceClient(notificationsConn),
 		ZitiDialer:           zitiManager,
-	}))
+	})
+	runnersv1.RegisterRunnersServiceServer(grpcServer, srv)
+	go srv.RunAgentActivitySweep(ctx, cfg.AgentActivitySweepInterval, cfg.KeepaliveGrace)
 
 	listener, err := net.Listen("tcp", cfg.GRPCAddr)
 	if err != nil {

--- a/cmd/runners/main.go
+++ b/cmd/runners/main.go
@@ -54,29 +54,38 @@ func run() error {
 		return fmt.Errorf("apply migrations: %w", err)
 	}
 
-	identityConn, err := grpc.DialContext(ctx, cfg.IdentityAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	closeConn := func(name string, conn *grpc.ClientConn) {
+		if conn == nil {
+			return
+		}
+		if err := conn.Close(); err != nil {
+			log.Printf("close %s connection: %v", name, err)
+		}
+	}
+
+	identityConn, err := grpc.NewClient(cfg.IdentityAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial identity service: %w", err)
 	}
-	defer identityConn.Close()
+	defer closeConn("identity", identityConn)
 
-	authorizationConn, err := grpc.DialContext(ctx, cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	authorizationConn, err := grpc.NewClient(cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial authorization service: %w", err)
 	}
-	defer authorizationConn.Close()
+	defer closeConn("authorization", authorizationConn)
 
-	agentsConn, err := grpc.DialContext(ctx, cfg.AgentsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	agentsConn, err := grpc.NewClient(cfg.AgentsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial agents service: %w", err)
 	}
-	defer agentsConn.Close()
+	defer closeConn("agents", agentsConn)
 
-	zitiManagementConn, err := grpc.DialContext(ctx, cfg.ZitiManagementAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	zitiManagementConn, err := grpc.NewClient(cfg.ZitiManagementAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial ziti management service: %w", err)
 	}
-	defer zitiManagementConn.Close()
+	defer closeConn("ziti management", zitiManagementConn)
 
 	zitiMgmtClient := zitimanagementv1.NewZitiManagementServiceClient(zitiManagementConn)
 	zitiManager, err := zitimanager.New(ctx, zitiMgmtClient, cfg.ZitiEnrollmentTimeout, cfg.ZitiLeaseRenewalInterval)
@@ -86,11 +95,11 @@ func run() error {
 	defer zitiManager.Close()
 	go zitiManager.RunLeaseRenewal(ctx)
 
-	notificationsConn, err := grpc.DialContext(ctx, cfg.NotificationsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	notificationsConn, err := grpc.NewClient(cfg.NotificationsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial notifications service: %w", err)
 	}
-	defer notificationsConn.Close()
+	defer closeConn("notifications", notificationsConn)
 
 	grpcServer := grpc.NewServer()
 	srv := server.New(server.Options{
@@ -109,7 +118,11 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", cfg.GRPCAddr, err)
 	}
-	defer listener.Close()
+	defer func() {
+		if err := listener.Close(); err != nil {
+			log.Printf("close listener: %v", err)
+		}
+	}()
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,9 +83,6 @@ func Load() (Config, error) {
 		}
 		cfg.AgentActivitySweepInterval = parsed
 	}
-	if cfg.AgentActivitySweepInterval <= 0 {
-		return Config{}, fmt.Errorf("AGENT_ACTIVITY_SWEEP_INTERVAL must be greater than 0")
-	}
 
 	keepaliveGrace := strings.TrimSpace(os.Getenv("KEEPALIVE_GRACE"))
 	if keepaliveGrace == "" {
@@ -96,9 +93,6 @@ func Load() (Config, error) {
 			return Config{}, fmt.Errorf("parse KEEPALIVE_GRACE: %w", err)
 		}
 		cfg.KeepaliveGrace = parsed
-	}
-	if cfg.KeepaliveGrace <= 0 {
-		return Config{}, fmt.Errorf("KEEPALIVE_GRACE must be greater than 0")
 	}
 
 	cfg.GRPCAddr = readEnv("GRPC_ADDR", defaultGRPCAddr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,15 +18,17 @@ const (
 
 // Config captures runtime configuration derived from the environment.
 type Config struct {
-	DatabaseURL              string
-	IdentityAddress          string
-	AuthorizationAddress     string
-	AgentsAddress            string
-	ZitiManagementAddress    string
-	NotificationsAddress     string
-	ZitiLeaseRenewalInterval time.Duration
-	ZitiEnrollmentTimeout    time.Duration
-	GRPCAddr                 string
+	DatabaseURL                string
+	IdentityAddress            string
+	AuthorizationAddress       string
+	AgentsAddress              string
+	ZitiManagementAddress      string
+	NotificationsAddress       string
+	ZitiLeaseRenewalInterval   time.Duration
+	ZitiEnrollmentTimeout      time.Duration
+	AgentActivitySweepInterval time.Duration
+	KeepaliveGrace             time.Duration
+	GRPCAddr                   string
 }
 
 // Load reads configuration from environment variables, applying defaults when
@@ -71,6 +73,34 @@ func Load() (Config, error) {
 	if cfg.ZitiEnrollmentTimeout <= 0 {
 		return Config{}, fmt.Errorf("ZITI_ENROLLMENT_TIMEOUT must be greater than 0")
 	}
+	sweepInterval := strings.TrimSpace(os.Getenv("AGENT_ACTIVITY_SWEEP_INTERVAL"))
+	if sweepInterval == "" {
+		cfg.AgentActivitySweepInterval = 5 * time.Second
+	} else {
+		parsed, err := time.ParseDuration(sweepInterval)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse AGENT_ACTIVITY_SWEEP_INTERVAL: %w", err)
+		}
+		cfg.AgentActivitySweepInterval = parsed
+	}
+	if cfg.AgentActivitySweepInterval <= 0 {
+		return Config{}, fmt.Errorf("AGENT_ACTIVITY_SWEEP_INTERVAL must be greater than 0")
+	}
+
+	keepaliveGrace := strings.TrimSpace(os.Getenv("KEEPALIVE_GRACE"))
+	if keepaliveGrace == "" {
+		cfg.KeepaliveGrace = 25 * time.Second
+	} else {
+		parsed, err := time.ParseDuration(keepaliveGrace)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse KEEPALIVE_GRACE: %w", err)
+		}
+		cfg.KeepaliveGrace = parsed
+	}
+	if cfg.KeepaliveGrace <= 0 {
+		return Config{}, fmt.Errorf("KEEPALIVE_GRACE must be greater than 0")
+	}
+
 	cfg.GRPCAddr = readEnv("GRPC_ADDR", defaultGRPCAddr)
 
 	return cfg, nil

--- a/internal/server/agent_activity_sweep.go
+++ b/internal/server/agent_activity_sweep.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -26,6 +27,9 @@ func (s *Server) RunAgentActivitySweep(ctx context.Context, interval, keepaliveG
 
 	for {
 		if err := s.agentActivitySweepOnce(ctx, keepaliveGrace); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
 			log.Printf("runners: agent activity sweep: %v", err)
 		}
 

--- a/internal/server/agent_activity_sweep.go
+++ b/internal/server/agent_activity_sweep.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+)
+
+// RunAgentActivitySweep flips workloads from agent_state=processing to agent_state=idle
+// when they have not received a keepalive within KEEPALIVE_GRACE.
+//
+// This is the sole writer of the processing -> idle transition.
+func (s *Server) RunAgentActivitySweep(ctx context.Context, interval, keepaliveGrace time.Duration) {
+	if interval <= 0 {
+		log.Printf("runners: agent activity sweep disabled: interval=%s", interval)
+		return
+	}
+	if keepaliveGrace <= 0 {
+		log.Printf("runners: agent activity sweep disabled: keepalive_grace=%s", keepaliveGrace)
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := s.agentActivitySweepOnce(ctx, keepaliveGrace); err != nil {
+			log.Printf("runners: agent activity sweep: %v", err)
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Server) agentActivitySweepOnce(ctx context.Context, keepaliveGrace time.Duration) error {
+	cutoff := time.Now().Add(-keepaliveGrace)
+	query := fmt.Sprintf(`
+		UPDATE workloads
+		SET agent_state = $1,
+			updated_at = NOW()
+		WHERE status = $2
+			AND agent_state = $3
+			AND removed_at IS NULL
+			AND last_activity_at < $4
+		RETURNING %s`, workloadColumns)
+
+	rows, err := s.pool.Query(ctx, query, workloadAgentStateIdle, workloadStatusRunning, workloadAgentStateProcessing, cutoff)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var updated []workloadRecord
+	for rows.Next() {
+		record, err := scanWorkload(rows)
+		if err != nil {
+			return err
+		}
+		updated = append(updated, record)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if s.notificationsClient == nil {
+		return nil
+	}
+	for _, workload := range updated {
+		s.publishWorkloadUpdateNotifications(ctx, workload, false, false, false, true)
+	}
+	return nil
+}

--- a/internal/server/list_utils.go
+++ b/internal/server/list_utils.go
@@ -17,15 +17,3 @@ func uniqueUUIDs(values []uuid.UUID) []uuid.UUID {
 	}
 	return unique
 }
-
-func compareUUID(a, b uuid.UUID) int {
-	aValue := a.String()
-	bValue := b.String()
-	if aValue < bValue {
-		return -1
-	}
-	if aValue > bValue {
-		return 1
-	}
-	return 0
-}

--- a/internal/server/pagination.go
+++ b/internal/server/pagination.go
@@ -40,7 +40,7 @@ func listWithPagination[T any](
 		query.WriteString(" WHERE ")
 		query.WriteString(strings.Join(clauses, " AND "))
 	}
-	query.WriteString(fmt.Sprintf(" ORDER BY id ASC LIMIT $%d", len(args)+1))
+	fmt.Fprintf(&query, " ORDER BY id ASC LIMIT $%d", len(args)+1)
 	args = append(args, int(limit)+1)
 
 	rows, err := pool.Query(ctx, query.String(), args...)

--- a/internal/server/query_helpers.go
+++ b/internal/server/query_helpers.go
@@ -5,21 +5,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const pendingSampleClause = "(removed_at IS NULL OR last_metering_sampled_at IS NULL OR removed_at > last_metering_sampled_at)"
-
-type listQueryInput struct {
-	Table          string
-	Columns        string
-	Statuses       []string
-	OrganizationID *uuid.UUID
-	RunnerID       *uuid.UUID
-	PendingSample  bool
-	PageToken      string
-	Limit          int32
-}
 
 func addUpdateClause(clauses *[]string, args *[]any, column string, value any) {
 	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)+1))
@@ -31,45 +19,4 @@ func buildUpdateQuery(table, columns string, clauses []string, args []any, id uu
 	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = $%d RETURNING %s", table, strings.Join(clauses, ", "), len(args)+1, columns)
 	args = append(args, id)
 	return query, args
-}
-
-func buildListQuery(input listQueryInput) (string, []any, error) {
-	var (
-		clauses []string
-		args    []any
-	)
-	if len(input.Statuses) > 0 {
-		clauses = append(clauses, fmt.Sprintf("status = ANY($%d)", len(args)+1))
-		args = append(args, pgtype.FlatArray[string](input.Statuses))
-	}
-	if input.OrganizationID != nil {
-		clauses = append(clauses, fmt.Sprintf("organization_id = $%d", len(args)+1))
-		args = append(args, *input.OrganizationID)
-	}
-	if input.RunnerID != nil {
-		clauses = append(clauses, fmt.Sprintf("runner_id = $%d", len(args)+1))
-		args = append(args, *input.RunnerID)
-	}
-	if input.PendingSample {
-		clauses = append(clauses, pendingSampleClause)
-	}
-	if input.PageToken != "" {
-		afterID, err := decodePageToken(input.PageToken)
-		if err != nil {
-			return "", nil, InvalidPageToken(err)
-		}
-		clauses = append(clauses, fmt.Sprintf("id > $%d", len(args)+1))
-		args = append(args, afterID)
-	}
-
-	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM %s", input.Columns, input.Table))
-	if len(clauses) > 0 {
-		query.WriteString(" WHERE ")
-		query.WriteString(strings.Join(clauses, " AND "))
-	}
-	query.WriteString(fmt.Sprintf(" ORDER BY id ASC LIMIT $%d", len(args)+1))
-	args = append(args, int(input.Limit)+1)
-
-	return query.String(), args, nil
 }

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -377,7 +377,6 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 	}
 
 	filter := volumeListFilter{OrganizationID: organizationID}
-	pendingSampleSet := false
 	if req.Filter != nil {
 		filter.RunnerIDs = make([]uuid.UUID, 0, len(req.Filter.RunnerIdIn))
 		for _, runnerValue := range req.Filter.RunnerIdIn {
@@ -403,29 +402,16 @@ func (s *Server) ListVolumes(ctx context.Context, req *runnersv1.ListVolumesRequ
 		}
 		if req.Filter.PendingSample != nil {
 			filter.PendingSample = req.Filter.GetPendingSample()
-			pendingSampleSet = true
 		}
 		if req.Filter.VolumeNameSubstring != nil {
 			filter.VolumeNameContains = strings.TrimSpace(req.Filter.GetVolumeNameSubstring())
 		}
 	}
 
-	if req.RunnerId != nil {
-		parsed, err := parseUUID(req.GetRunnerId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
-		}
-		filter.RunnerIDs = append(filter.RunnerIDs, parsed)
-	}
-	if req.PendingSample != nil && !pendingSampleSet {
-		filter.PendingSample = req.GetPendingSample()
-	}
-
 	statusFilters := make([]runnersv1.VolumeStatus, 0)
 	if req.Filter != nil {
 		statusFilters = append(statusFilters, req.Filter.StatusIn...)
 	}
-	statusFilters = append(statusFilters, req.GetStatuses()...)
 	statuses, err := volumeStatusesToStrings(statusFilters)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
@@ -717,10 +703,10 @@ func (s *Server) listVolumesByThread(ctx context.Context, threadID uuid.UUID, pa
 	}
 
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	fmt.Fprintf(&query, "SELECT %s FROM volumes", volumeColumns)
 	query.WriteString(" WHERE ")
 	query.WriteString(strings.Join(clauses, " AND "))
-	query.WriteString(fmt.Sprintf(" ORDER BY id ASC LIMIT $%d", len(args)+1))
+	fmt.Fprintf(&query, " ORDER BY id ASC LIMIT $%d", len(args)+1)
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)
@@ -990,12 +976,12 @@ func (s *Server) listVolumesPage(ctx context.Context, filter volumeListFilter, s
 	}
 
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	fmt.Fprintf(&query, "SELECT %s FROM volumes", volumeColumns)
 	if len(clauses) > 0 {
 		query.WriteString(" WHERE ")
 		query.WriteString(strings.Join(clauses, " AND "))
 	}
-	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, volumes.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1))
+	fmt.Fprintf(&query, " ORDER BY %s %s, volumes.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1)
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)
@@ -1079,12 +1065,12 @@ func (s *Server) listVolumesByNamePage(ctx context.Context, filter volumeListFil
 	}
 
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM volumes", volumeColumns))
+	fmt.Fprintf(&query, "SELECT %s FROM volumes", volumeColumns)
 	if len(clauses) > 0 {
 		query.WriteString(" WHERE ")
 		query.WriteString(strings.Join(clauses, " AND "))
 	}
-	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, volumes.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1))
+	fmt.Fprintf(&query, " ORDER BY %s %s, volumes.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1)
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)
@@ -1421,24 +1407,6 @@ func matchesVolumeAttachmentKinds(attachments []*runnersv1.Attachment, kindFilte
 		}
 	}
 	return false
-}
-
-func paginateVolumeItems(items []volumeListItem, sort volumeListSort, pageSize int32) ([]volumeListItem, string, error) {
-	limit := normalizePageSize(pageSize)
-	if len(items) <= int(limit) {
-		return items, "", nil
-	}
-	page := items[:limit]
-	lastItem := page[len(page)-1]
-	primary, err := volumePrimaryValue(lastItem, sort.Field)
-	if err != nil {
-		return nil, "", err
-	}
-	nextToken, err := encodeListCursor(primary, lastItem.record.Meta.ID)
-	if err != nil {
-		return nil, "", err
-	}
-	return page, nextToken, nil
 }
 
 func (s *Server) batchUpdateVolumeSampledAt(ctx context.Context, entries []sampledAtEntry) error {

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -240,7 +240,12 @@ func TestListVolumesFiltersRunner(t *testing.T) {
 	runnerIDValue := runnerID.String()
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, RunnerId: &runnerIDValue})
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{
+		OrganizationId: &organizationIDValue,
+		Filter: &runnersv1.ListVolumesFilter{
+			RunnerIdIn: []string{runnerIDValue},
+		},
+	})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
@@ -314,7 +319,12 @@ func TestListVolumesPendingSample(t *testing.T) {
 	pendingSample := true
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, PendingSample: &pendingSample})
+	resp, err := srv.ListVolumes(ctx, &runnersv1.ListVolumesRequest{
+		OrganizationId: &organizationIDValue,
+		Filter: &runnersv1.ListVolumesFilter{
+			PendingSample: &pendingSample,
+		},
+	})
 	if err != nil {
 		t.Fatalf("ListVolumes failed: %v", err)
 	}
@@ -592,7 +602,10 @@ func TestListVolumesInvalidUUID(t *testing.T) {
 			name: "runner_id",
 			req: func() *runnersv1.ListVolumesRequest {
 				value := "not-a-uuid"
-				return &runnersv1.ListVolumesRequest{OrganizationId: &organizationIDValue, RunnerId: &value}
+				return &runnersv1.ListVolumesRequest{
+					OrganizationId: &organizationIDValue,
+					Filter:         &runnersv1.ListVolumesFilter{RunnerIdIn: []string{value}},
+				}
 			}(),
 		},
 	}

--- a/internal/server/workload_logs.go
+++ b/internal/server/workload_logs.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -80,21 +81,16 @@ func (s *Server) StreamWorkloadLogs(req *runnerv1.StreamWorkloadLogsRequest, str
 		}
 		return status.Errorf(codes.Unavailable, "dial runner: %v", err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Printf("runners: close runner connection: %v", err)
+		}
+	}()
 
 	// workload_id here is the platform workload UUID; runner expects instance_id.
-	runnerReq := &runnerv1.StreamWorkloadLogsRequest{
-		WorkloadId:    instanceID,
-		Follow:        req.GetFollow(),
-		Since:         req.GetSince(),
-		Tail:          req.GetTail(),
-		Stdout:        req.GetStdout(),
-		Stderr:        req.GetStderr(),
-		Timestamps:    req.GetTimestamps(),
-		ContainerName: containerName,
-		TailLines:     req.GetTailLines(),
-		SinceTime:     req.GetSinceTime(),
-	}
+	runnerReq := proto.Clone(req).(*runnerv1.StreamWorkloadLogsRequest)
+	runnerReq.WorkloadId = instanceID
+	runnerReq.ContainerName = containerName
 
 	runnerClient := runnerv1.NewRunnerServiceClient(conn)
 	grpcStream, err := runnerClient.StreamWorkloadLogs(ctx, runnerReq)

--- a/internal/server/workload_logs_test.go
+++ b/internal/server/workload_logs_test.go
@@ -131,7 +131,7 @@ func TestStreamWorkloadLogsProxiesRunnerStream(t *testing.T) {
 	}
 
 	workloadRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
 	workloadQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(workloadQuery)).
 		WithArgs(workloadID).
@@ -238,7 +238,7 @@ func TestStreamWorkloadLogsRequiresViewWorkloads(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	workloadRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), "instance-1", now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), "instance-1", now, nil, nil, now, now)
 	workloadQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(workloadQuery)).
 		WithArgs(workloadID).
@@ -295,7 +295,7 @@ func TestStreamWorkloadLogsMissingInstanceID(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	workloadRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 	workloadQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(workloadQuery)).
 		WithArgs(workloadID).

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
+
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -30,6 +31,9 @@ const (
 	workloadStatusStopped  = "stopped"
 	workloadStatusFailed   = "failed"
 
+	workloadAgentStateProcessing = "processing"
+	workloadAgentStateIdle       = "idle"
+
 	workloadFailureReasonStartFailed     = "start_failed"
 	workloadFailureReasonImagePullFailed = "image_pull_failed"
 	workloadFailureReasonConfigInvalid   = "config_invalid"
@@ -44,7 +48,7 @@ const (
 	containerStatusTerminated = "terminated"
 	containerStatusWaiting    = "waiting"
 
-	workloadColumns = `id, runner_id, thread_id, agent_id, organization_id, status, failure_reason, failure_message, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, instance_id, last_activity_at, last_metering_sampled_at, removed_at, created_at, updated_at`
+	workloadColumns = `id, runner_id, thread_id, agent_id, organization_id, status, agent_state, failure_reason, failure_message, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, instance_id, last_activity_at, last_metering_sampled_at, removed_at, created_at, updated_at`
 )
 
 type workloadRecord struct {
@@ -54,6 +58,7 @@ type workloadRecord struct {
 	AgentID                uuid.UUID
 	OrganizationID         uuid.UUID
 	Status                 string
+	AgentState             string
 	FailureReason          *string
 	FailureMessage         *string
 	Containers             []containerRecord
@@ -82,6 +87,8 @@ type workloadInsertInput struct {
 type workloadUpdateInput struct {
 	ID             uuid.UUID
 	Status         *string
+	AgentState     *string
+	LastActivityAt *time.Time
 	FailureReason  *string
 	FailureMessage *string
 	ContainersJSON *[]byte
@@ -290,7 +297,7 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 	failureReasonChanged := existingWorkload != nil && failureReason != nil && (existingWorkload.FailureReason == nil || *existingWorkload.FailureReason != *failureReason)
 	failureMessageChanged := existingWorkload != nil && failureMessage != nil && (existingWorkload.FailureMessage == nil || *existingWorkload.FailureMessage != *failureMessage)
 	if statusChanged || containersChanged || failureReasonChanged || failureMessageChanged {
-		s.publishWorkloadUpdateNotifications(ctx, workload, statusChanged, containersChanged, failureReasonChanged || failureMessageChanged)
+		s.publishWorkloadUpdateNotifications(ctx, workload, statusChanged, containersChanged, failureReasonChanged || failureMessageChanged, false)
 	}
 	protoWorkload, err := toProtoWorkload(workload)
 	if err != nil {
@@ -299,13 +306,14 @@ func (s *Server) UpdateWorkload(ctx context.Context, req *runnersv1.UpdateWorklo
 	return &runnersv1.UpdateWorkloadResponse{Workload: protoWorkload}, nil
 }
 
-func (s *Server) publishWorkloadUpdateNotifications(ctx context.Context, workload workloadRecord, statusChanged, containersChanged, failureChanged bool) {
+func (s *Server) publishWorkloadUpdateNotifications(ctx context.Context, workload workloadRecord, statusChanged, containersChanged, failureChanged, agentStateChanged bool) {
 	if s.notificationsClient == nil {
 		return
 	}
 	payloadFields := map[string]any{
 		"workload_id": workload.Meta.ID.String(),
 		"status":      workload.Status,
+		"agent_state": workload.AgentState,
 	}
 	if workload.FailureReason != nil {
 		payloadFields["failure_reason"] = *workload.FailureReason
@@ -323,7 +331,7 @@ func (s *Server) publishWorkloadUpdateNotifications(ctx context.Context, workloa
 		fmt.Sprintf("organization:%s", workload.OrganizationID.String()),
 		workloadRoom,
 	}
-	if statusChanged || containersChanged || failureChanged {
+	if statusChanged || containersChanged || failureChanged || agentStateChanged {
 		s.publishWorkloadNotification(ctx, "workload.updated", updatedRooms, payload)
 	}
 	if statusChanged {
@@ -388,8 +396,16 @@ func (s *Server) TouchWorkload(ctx context.Context, req *runnersv1.TouchWorkload
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	if err := s.touchWorkloadForAgent(ctx, id, callerID); err != nil {
+	agentStateChanged, err := s.touchWorkloadForAgent(ctx, id, callerID)
+	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if agentStateChanged {
+		workload, err := s.getWorkloadByID(ctx, id)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		s.publishWorkloadUpdateNotifications(ctx, workload, false, false, false, true)
 	}
 	return &runnersv1.TouchWorkloadResponse{}, nil
 }
@@ -644,6 +660,17 @@ func (s *Server) updateWorkload(ctx context.Context, input workloadUpdateInput) 
 	if input.Status != nil {
 		addUpdateClause(&clauses, &args, "status", *input.Status)
 	}
+	if input.AgentState != nil {
+		addUpdateClause(&clauses, &args, "agent_state", *input.AgentState)
+	}
+	if input.LastActivityAt != nil {
+		addUpdateClause(&clauses, &args, "last_activity_at", *input.LastActivityAt)
+	} else if input.Status != nil && *input.Status == workloadStatusRunning {
+		// Reset last_activity_at on the starting -> running transition so the agent
+		// gets a fresh keepalive window once the container is up.
+		clauses = append(clauses, fmt.Sprintf("last_activity_at = CASE WHEN status = $%d THEN NOW() ELSE last_activity_at END", len(args)+1))
+		args = append(args, workloadStatusStarting)
+	}
 	if input.FailureReason != nil {
 		addUpdateClause(&clauses, &args, "failure_reason", *input.FailureReason)
 	}
@@ -711,19 +738,38 @@ func (s *Server) softDeleteWorkload(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (s *Server) touchWorkloadForAgent(ctx context.Context, id uuid.UUID, agentID uuid.UUID) error {
-	result, err := s.pool.Exec(ctx, `UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1 AND agent_id = $2`, id, agentID)
+func (s *Server) touchWorkloadForAgent(ctx context.Context, id uuid.UUID, agentID uuid.UUID) (bool, error) {
+	var agentStateChanged bool
+	err := s.pool.QueryRow(ctx, `
+		UPDATE workloads AS w
+		SET last_activity_at = NOW(),
+			updated_at = NOW(),
+			agent_state = CASE
+				WHEN old.agent_state = $3 THEN $4
+				ELSE old.agent_state
+			END
+		FROM (
+			SELECT id, agent_state FROM workloads WHERE id = $1 AND agent_id = $2
+		) AS old
+		WHERE w.id = old.id
+		RETURNING (old.agent_state = $3) AS agent_state_changed
+	`,
+		id,
+		agentID,
+		workloadAgentStateIdle,
+		workloadAgentStateProcessing,
+	).Scan(&agentStateChanged)
 	if err != nil {
-		return err
-	}
-	if result.RowsAffected() == 0 {
-		_, err := s.getWorkloadByID(ctx, id)
-		if err != nil {
-			return err
+		if errors.Is(err, pgx.ErrNoRows) {
+			_, err := s.getWorkloadByID(ctx, id)
+			if err != nil {
+				return false, err
+			}
+			return false, PermissionDenied()
 		}
-		return PermissionDenied()
+		return false, err
 	}
-	return nil
+	return agentStateChanged, nil
 }
 
 func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, agentID *uuid.UUID, statuses []string, pageSize int32, pageToken string) ([]workloadRecord, string, error) {
@@ -1191,6 +1237,7 @@ func scanWorkload(row pgx.Row) (workloadRecord, error) {
 		&workload.AgentID,
 		&workload.OrganizationID,
 		&workload.Status,
+		&workload.AgentState,
 		&failureReason,
 		&failureMessage,
 		&containersData,
@@ -1240,6 +1287,11 @@ func toProtoWorkload(record workloadRecord) (*runnersv1.Workload, error) {
 	if err != nil {
 		return nil, err
 	}
+	agentStateValue, err := workloadAgentStateFromString(record.AgentState)
+	if err != nil {
+		return nil, err
+	}
+
 	containers, err := containersToProto(record.Containers)
 	if err != nil {
 		return nil, err
@@ -1251,6 +1303,7 @@ func toProtoWorkload(record workloadRecord) (*runnersv1.Workload, error) {
 		AgentId:                record.AgentID.String(),
 		OrganizationId:         record.OrganizationID.String(),
 		Status:                 statusValue,
+		AgentState:             agentStateValue,
 		Containers:             containers,
 		ZitiIdentityId:         record.ZitiIdentityID,
 		LastActivityAt:         timestamppb.New(record.LastActivityAt),
@@ -1524,6 +1577,17 @@ func workloadStatusFromString(value string) (runnersv1.WorkloadStatus, error) {
 		return runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, nil
 	default:
 		return runnersv1.WorkloadStatus_WORKLOAD_STATUS_UNSPECIFIED, fmt.Errorf("invalid workload status: %s", value)
+	}
+}
+
+func workloadAgentStateFromString(value string) (runnersv1.WorkloadAgentState, error) {
+	switch value {
+	case workloadAgentStateProcessing:
+		return runnersv1.WorkloadAgentState_WORKLOAD_AGENT_STATE_PROCESSING, nil
+	case workloadAgentStateIdle:
+		return runnersv1.WorkloadAgentState_WORKLOAD_AGENT_STATE_IDLE, nil
+	default:
+		return runnersv1.WorkloadAgentState_WORKLOAD_AGENT_STATE_UNSPECIFIED, fmt.Errorf("invalid workload agent state: %s", value)
 	}
 }
 

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -48,7 +48,7 @@ const (
 	containerStatusTerminated = "terminated"
 	containerStatusWaiting    = "waiting"
 
-	workloadColumns = `id, runner_id, thread_id, agent_id, organization_id, status, agent_state, failure_reason, failure_message, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, instance_id, last_activity_at, last_metering_sampled_at, removed_at, created_at, updated_at`
+	workloadColumns = `workloads.id, workloads.runner_id, workloads.thread_id, workloads.agent_id, workloads.organization_id, workloads.status, workloads.agent_state, workloads.failure_reason, workloads.failure_message, workloads.containers, workloads.ziti_identity_id, workloads.allocated_cpu_millicores, workloads.allocated_ram_bytes, workloads.instance_id, workloads.last_activity_at, workloads.last_metering_sampled_at, workloads.removed_at, workloads.created_at, workloads.updated_at`
 )
 
 type workloadRecord struct {
@@ -522,7 +522,6 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 	}
 
 	filter := workloadListFilter{OrganizationID: organizationID}
-	pendingSampleSet := false
 	if req.Filter != nil {
 		filter.AgentIDs = make([]uuid.UUID, 0, len(req.Filter.AgentIdIn))
 		for _, agentValue := range req.Filter.AgentIdIn {
@@ -556,26 +555,13 @@ func (s *Server) ListWorkloads(ctx context.Context, req *runnersv1.ListWorkloads
 		}
 		if req.Filter.PendingSample != nil {
 			filter.PendingSample = req.Filter.GetPendingSample()
-			pendingSampleSet = true
 		}
-	}
-
-	if req.RunnerId != nil {
-		parsed, err := parseUUID(req.GetRunnerId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
-		}
-		filter.RunnerIDs = append(filter.RunnerIDs, parsed)
-	}
-	if req.PendingSample != nil && !pendingSampleSet {
-		filter.PendingSample = req.GetPendingSample()
 	}
 
 	statusFilters := make([]runnersv1.WorkloadStatus, 0)
 	if req.Filter != nil {
 		statusFilters = append(statusFilters, req.Filter.StatusIn...)
 	}
-	statusFilters = append(statusFilters, req.GetStatuses()...)
 	statuses, err := workloadStatusesToStrings(statusFilters)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
@@ -796,10 +782,10 @@ func (s *Server) listWorkloadsByThread(ctx context.Context, threadID uuid.UUID, 
 	}
 
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM workloads", workloadColumns))
+	fmt.Fprintf(&query, "SELECT %s FROM workloads", workloadColumns)
 	query.WriteString(" WHERE ")
 	query.WriteString(strings.Join(clauses, " AND "))
-	query.WriteString(fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", len(args)+1))
+	fmt.Fprintf(&query, " ORDER BY created_at DESC, id DESC LIMIT $%d", len(args)+1)
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)
@@ -1113,13 +1099,13 @@ func (s *Server) listWorkloads(ctx context.Context, filter workloadListFilter, s
 	}
 
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf("SELECT %s FROM workloads", workloadColumns))
+	fmt.Fprintf(&query, "SELECT %s FROM workloads", workloadColumns)
 	query.WriteString(joinClause)
 	if len(clauses) > 0 {
 		query.WriteString(" WHERE ")
 		query.WriteString(strings.Join(clauses, " AND "))
 	}
-	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, workloads.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1))
+	fmt.Fprintf(&query, " ORDER BY %s %s, workloads.id ASC LIMIT $%d", sortColumn, sort.Direction, len(args)+1)
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -253,7 +253,12 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	runnerIDValue := runnerID.String()
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, RunnerId: &runnerIDValue})
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{
+		OrganizationId: &organizationIDValue,
+		Filter: &runnersv1.ListWorkloadsFilter{
+			RunnerIdIn: []string{runnerIDValue},
+		},
+	})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
@@ -330,7 +335,12 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	pendingSample := true
 	organizationIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
-	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, PendingSample: &pendingSample})
+	resp, err := srv.ListWorkloads(ctx, &runnersv1.ListWorkloadsRequest{
+		OrganizationId: &organizationIDValue,
+		Filter: &runnersv1.ListWorkloadsFilter{
+			PendingSample: &pendingSample,
+		},
+	})
 	if err != nil {
 		t.Fatalf("ListWorkloads failed: %v", err)
 	}
@@ -540,7 +550,10 @@ func TestListWorkloadsInvalidUUID(t *testing.T) {
 			name: "runner_id",
 			req: func() *runnersv1.ListWorkloadsRequest {
 				value := "not-a-uuid"
-				return &runnersv1.ListWorkloadsRequest{OrganizationId: &organizationIDValue, RunnerId: &value}
+				return &runnersv1.ListWorkloadsRequest{
+					OrganizationId: &organizationIDValue,
+					Filter:         &runnersv1.ListWorkloadsFilter{RunnerIdIn: []string{value}},
+				}
 			}(),
 		},
 	}
@@ -892,6 +905,77 @@ func TestTouchWorkload(t *testing.T) {
 	_, err = srv.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID.String()})
 	if err != nil {
 		t.Fatalf("TouchWorkload failed: %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestTouchWorkloadIdleToProcessingPublishesNotification(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	agentID := uuid.New()
+	callerID := agentID
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	query := regexp.QuoteMeta("UPDATE workloads AS w")
+	rows := pgxmock.NewRows([]string{"agent_state_changed"}).AddRow(true)
+	mockPool.ExpectQuery(query).
+		WithArgs(workloadID, callerID, workloadAgentStateIdle, workloadAgentStateProcessing).
+		WillReturnRows(rows)
+
+	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	workloadRows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).WithArgs(workloadID).WillReturnRows(workloadRows)
+
+	published := make([]*notificationsv1.PublishRequest, 0, 1)
+	notificationsClient := fakeNotificationsClient{publish: func(ctx context.Context, req *notificationsv1.PublishRequest) (*notificationsv1.PublishResponse, error) {
+		published = append(published, req)
+		return &notificationsv1.PublishResponse{}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, NotificationsClient: notificationsClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.TouchWorkload(ctx, &runnersv1.TouchWorkloadRequest{Id: workloadID.String()})
+	if err != nil {
+		t.Fatalf("TouchWorkload failed: %v", err)
+	}
+	if len(published) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(published))
+	}
+
+	req := published[0]
+	if req.GetEvent() != "workload.updated" {
+		t.Fatalf("expected workload.updated event, got %s", req.GetEvent())
+	}
+	if req.GetSource() != "runners" {
+		t.Fatalf("expected source runners, got %q", req.GetSource())
+	}
+	rooms := req.GetRooms()
+	workloadRoom := fmt.Sprintf("workload:%s", workloadID)
+	orgRoom := fmt.Sprintf("organization:%s", organizationID)
+	if len(rooms) != 2 || !hasRoom(rooms, workloadRoom) || !hasRoom(rooms, orgRoom) {
+		t.Fatalf("unexpected rooms: %v", rooms)
+	}
+	payload := req.GetPayload().AsMap()
+	if payload["workload_id"] != workloadID.String() {
+		t.Fatalf("unexpected workload_id payload: %v", payload["workload_id"])
+	}
+	if payload["status"] != workloadStatusRunning {
+		t.Fatalf("unexpected status payload: %v", payload["status"])
+	}
+	if payload["agent_state"] != workloadAgentStateProcessing {
+		t.Fatalf("unexpected agent_state payload: %v", payload["agent_state"])
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -31,6 +31,7 @@ var workloadRowColumns = []string{
 	"agent_id",
 	"organization_id",
 	"status",
+	"agent_state",
 	"failure_reason",
 	"failure_message",
 	"containers",
@@ -76,7 +77,7 @@ func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -152,7 +153,7 @@ func TestListWorkloadsInternalNoIdentity(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	limit := normalizePageSize(0)
 	query := fmt.Sprintf("SELECT %s FROM workloads ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $1", workloadColumns)
@@ -221,7 +222,7 @@ func TestListWorkloadsFiltersRunner(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND workloads.runner_id = ANY($2) ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $3", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -299,7 +300,7 @@ func TestListWorkloadsPendingSample(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND %s ORDER BY workloads.created_at DESC, workloads.id ASC LIMIT $2", workloadColumns, pendingSampleClause)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -368,7 +369,7 @@ func TestListWorkloadsCursorPagination(t *testing.T) {
 	}
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	pageSize := int32(2)
 	limit := normalizePageSize(pageSize)
@@ -430,7 +431,7 @@ func TestListWorkloadsSortByAgentQuery(t *testing.T) {
 	sortExpr := "CASE workloads.agent_id WHEN $2 THEN $3 END"
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE workloads.organization_id = $1 AND (%s > $4 OR (%s = $4 AND workloads.id > $5)) ORDER BY %s ASC, workloads.id ASC LIMIT $6", workloadColumns, sortExpr, sortExpr, sortExpr)
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, agentID, primary, primary, cursorID, int(limit)+1).
 		WillReturnRows(rows)
@@ -486,7 +487,7 @@ func TestListWorkloadsSortByRunnerQuery(t *testing.T) {
 	sortColumn := "LOWER(runners.name)"
 	query := fmt.Sprintf("SELECT %s FROM workloads JOIN runners ON workloads.runner_id = runners.id WHERE workloads.organization_id = $1 AND (%s < $2 OR (%s = $2 AND workloads.id > $3)) ORDER BY %s DESC, workloads.id ASC LIMIT $4", workloadColumns, sortColumn, sortColumn, sortColumn)
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(organizationID, primary, cursorID, int(limit)+1).
 		WillReturnRows(rows)
@@ -637,7 +638,7 @@ func TestListWorkloadsByThreadFilters(t *testing.T) {
 	limit := normalizePageSize(pageSize)
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 AND agent_id = $2 AND status = ANY($3) ORDER BY created_at DESC, id DESC LIMIT $4", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -677,7 +678,7 @@ func TestListWorkloadsByThreadInternalNoIdentity(t *testing.T) {
 	limit := normalizePageSize(0)
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 ORDER BY created_at DESC, id DESC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -738,9 +739,9 @@ func TestListWorkloadsByThreadPagination(t *testing.T) {
 	thirdID := uuid.New()
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(firstID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, firstAt, nil, nil, firstAt, firstAt).
-		AddRow(secondID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, secondAt, nil, nil, secondAt, secondAt).
-		AddRow(thirdID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, thirdAt, nil, nil, thirdAt, thirdAt)
+		AddRow(firstID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, firstAt, nil, nil, firstAt, firstAt).
+		AddRow(secondID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, secondAt, nil, nil, secondAt, secondAt).
+		AddRow(thirdID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, thirdAt, nil, nil, thirdAt, thirdAt)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 AND (created_at < $2 OR (created_at = $2 AND id < $3)) ORDER BY created_at DESC, id DESC LIMIT $4", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -784,8 +785,8 @@ func TestListWorkloadsByThreadPaginationTieBreak(t *testing.T) {
 	secondID := uuid.MustParse("00000000-0000-0000-0000-000000000000")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(firstID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, createdAt, nil, nil, createdAt, createdAt).
-		AddRow(secondID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, createdAt, nil, nil, createdAt, createdAt)
+		AddRow(firstID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, createdAt, nil, nil, createdAt, createdAt).
+		AddRow(secondID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, createdAt, nil, nil, createdAt, createdAt)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 ORDER BY created_at DESC, id DESC LIMIT $2", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
@@ -839,7 +840,7 @@ func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
@@ -880,10 +881,11 @@ func TestTouchWorkload(t *testing.T) {
 	agentID := uuid.New()
 	callerID := agentID
 
-	query := "UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1 AND agent_id = $2"
-	mockPool.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(workloadID, callerID).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	query := regexp.QuoteMeta("UPDATE workloads AS w")
+	rows := pgxmock.NewRows([]string{"agent_state_changed"}).AddRow(false)
+	mockPool.ExpectQuery(query).
+		WithArgs(workloadID, callerID, workloadAgentStateIdle, workloadAgentStateProcessing).
+		WillReturnRows(rows)
 
 	srv := New(Options{Pool: mockPool})
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
@@ -912,14 +914,14 @@ func TestTouchWorkloadRequiresAgentIdentity(t *testing.T) {
 	now := time.Now().UTC()
 	containersJSON := []byte("[]")
 
-	query := "UPDATE workloads SET last_activity_at = NOW(), updated_at = NOW() WHERE id = $1 AND agent_id = $2"
-	mockPool.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(workloadID, callerID).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	query := regexp.QuoteMeta("UPDATE workloads AS w")
+	mockPool.ExpectQuery(query).
+		WithArgs(workloadID, callerID, workloadAgentStateIdle, workloadAgentStateProcessing).
+		WillReturnRows(pgxmock.NewRows([]string{"agent_state_changed"}))
 
 	getQuery := fmt.Sprintf(`SELECT %s FROM workloads WHERE id = $1`, workloadColumns)
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 	mockPool.ExpectQuery(regexp.QuoteMeta(getQuery)).WithArgs(workloadID).WillReturnRows(rows)
 
 	srv := New(Options{Pool: mockPool})
@@ -975,11 +977,11 @@ func TestUpdateWorkload(t *testing.T) {
 	}
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), instanceID, now, nil, nil, now, now)
 
-	query := fmt.Sprintf("UPDATE workloads SET status = $1, containers = $2, instance_id = $3, updated_at = NOW() WHERE id = $4 RETURNING %s", workloadColumns)
+	query := fmt.Sprintf("UPDATE workloads SET status = $1, last_activity_at = CASE WHEN status = $2 THEN NOW() ELSE last_activity_at END, containers = $3, instance_id = $4, updated_at = NOW() WHERE id = $5 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(workloadStatusRunning, containersJSON, instanceID, workloadID).
+		WithArgs(workloadStatusRunning, workloadStatusStarting, containersJSON, instanceID, workloadID).
 		WillReturnRows(rows)
 
 	srv := New(Options{Pool: mockPool})
@@ -1016,7 +1018,7 @@ func TestUpdateWorkloadPublishesNotifications(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	selectRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStarting, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStarting, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
@@ -1051,11 +1053,11 @@ func TestUpdateWorkloadPublishesNotifications(t *testing.T) {
 	}
 
 	updateRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, updatedContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, updatedContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
-	updateQuery := fmt.Sprintf("UPDATE workloads SET status = $1, containers = $2, updated_at = NOW() WHERE id = $3 RETURNING %s", workloadColumns)
+	updateQuery := fmt.Sprintf("UPDATE workloads SET status = $1, last_activity_at = CASE WHEN status = $2 THEN NOW() ELSE last_activity_at END, containers = $3, updated_at = NOW() WHERE id = $4 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
-		WithArgs(workloadStatusRunning, updatedContainersJSON, workloadID).
+		WithArgs(workloadStatusRunning, workloadStatusStarting, updatedContainersJSON, workloadID).
 		WillReturnRows(updateRows)
 
 	published := make([]*notificationsv1.PublishRequest, 0, 2)
@@ -1136,7 +1138,7 @@ func TestUpdateWorkloadFailureMetadata(t *testing.T) {
 	failureMessage := "back-off"
 
 	selectRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
@@ -1144,7 +1146,7 @@ func TestUpdateWorkloadFailureMetadata(t *testing.T) {
 		WillReturnRows(selectRows)
 
 	updateRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, failureReason, failureMessage, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, failureReason, failureMessage, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	updateQuery := fmt.Sprintf("UPDATE workloads SET failure_reason = $1, failure_message = $2, updated_at = NOW() WHERE id = $3 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
@@ -1255,7 +1257,7 @@ func TestUpdateWorkloadSkipsNotificationsWhenContainersUnchanged(t *testing.T) {
 	}
 
 	selectRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, existingContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, existingContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	selectQuery := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(selectQuery)).
@@ -1273,7 +1275,7 @@ func TestUpdateWorkloadSkipsNotificationsWhenContainersUnchanged(t *testing.T) {
 	}
 
 	updateRows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, nil, nil, requestContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, requestContainersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
 
 	updateQuery := fmt.Sprintf("UPDATE workloads SET containers = $1, updated_at = NOW() WHERE id = $2 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(updateQuery)).
@@ -1370,7 +1372,7 @@ func TestSoftDeleteWorkload(t *testing.T) {
 	containersJSON := []byte("[]")
 
 	rows := pgxmock.NewRows(workloadRowColumns).
-		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStopped, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, now, now, now)
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusStopped, workloadAgentStateIdle, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, now, now, now)
 
 	query := fmt.Sprintf("UPDATE workloads SET status = $1, removed_at = NOW(), updated_at = NOW() WHERE id = $2 RETURNING %s", workloadColumns)
 	mockPool.ExpectQuery(regexp.QuoteMeta(query)).

--- a/migrations/0009_add_workload_agent_state.sql
+++ b/migrations/0009_add_workload_agent_state.sql
@@ -1,0 +1,10 @@
+ALTER TABLE workloads
+ADD COLUMN IF NOT EXISTS agent_state TEXT NOT NULL DEFAULT 'processing'
+    CHECK (agent_state IN ('processing', 'idle'));
+
+CREATE INDEX IF NOT EXISTS idx_workloads_agent_state ON workloads (agent_state);
+
+-- Supports the Agent Activity Sweep query.
+CREATE INDEX IF NOT EXISTS idx_workloads_agent_activity_sweep
+    ON workloads (last_activity_at)
+    WHERE status = 'running' AND agent_state = 'processing' AND removed_at IS NULL;


### PR DESCRIPTION
Implements `Workload.agent_state` (processing/idle) to separate container lifecycle from agent activity.

Changes:
- DB migration: add `workloads.agent_state` (default `processing`) + indexes.
- Populate `Workload.agent_state` in proto conversion.
- `TouchWorkload`: atomically flips `idle -> processing` and only emits `workload.updated` on that transition.
- Agent Activity Sweep: flips `processing -> idle` when `status=running` and `last_activity_at` is older than `KEEPALIVE_GRACE`.
- Notifications: `workload.updated` payload now includes `agent_state`.

Config:
- `AGENT_ACTIVITY_SWEEP_INTERVAL` (default 5s)
- `KEEPALIVE_GRACE` (default 25s)

Notes:
- Depends on agynio/api PR #139 (proto field + enum).
- Unit tests updated (`CGO_ENABLED=0 go test ./...`).