### PR TITLE
fix: include agents buf path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY buf.gen.yaml buf.yaml ./
 RUN buf generate buf.build/agynio/api \
     --include-imports \
+    --path agynio/api/agents/v1 \
     --path agynio/api/runners/v1 \
     --path agynio/api/identity/v1 \
     --path agynio/api/authorization/v1 \


### PR DESCRIPTION
## Summary
- include agynio/api/agents/v1 in the Dockerfile buf generate allowlist

## Testing
- rm -rf .gen && buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/runners/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/notifications/v1
- go build ./cmd/runners
- go test ./...
- go vet ./...

Closes #50