### PR TITLE
test(e2e): use latest agent init images

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,10 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
-  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
+  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:latest
   CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
   AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
 
 jobs:


### PR DESCRIPTION
## Summary
- use latest agent-init-agn and agent-init-codex images in e2e workflow
- use latest agent-init-agn for expose e2e as well