### PR TITLE
ci: align e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Deploy runners from source
         run: |
           set -euo pipefail
-          devspace dev --watch > /tmp/runners-devspace.log 2>&1 &
+          RUNNER_TRACKING_ID="" devspace dev --watch > /tmp/runners-devspace.log 2>&1 &
           echo "$!" > /tmp/runners-devspace.pid
           devspace run-pipeline wait-runners
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,11 @@ jobs:
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Deploy runners from source
-        run: devspace dev
+        run: |
+          set -euo pipefail
+          devspace dev --watch > /tmp/runners-devspace.log 2>&1 &
+          echo "$!" > /tmp/runners-devspace.pid
+          devspace run-pipeline wait-runners
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
@@ -36,4 +40,10 @@ jobs:
 
       - name: Restore ArgoCD sync
         if: always()
-        run: devspace run-pipeline restore-argocd
+        run: |
+          set +e
+          if [ -f /tmp/runners-devspace.pid ]; then
+            kill "$(cat /tmp/runners-devspace.pid)"
+            wait "$(cat /tmp/runners-devspace.pid)"
+          fi
+          devspace run-pipeline restore-argocd

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,59 +5,35 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
-
-env:
-  AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
-  CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:latest
-  CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
-  AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
-  AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          path: service
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
-        env:
-          TF_VAR_ziti_management_chart_version: "0.10.10"
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Checkout agents-orchestrator
-        uses: actions/checkout@v4
-        with:
-          repository: agynio/agents-orchestrator
-          ref: cd934479a503d27998d34e01872fa1e885319cb9
-          path: agents-orchestrator
-
       - name: Deploy runners from source
-        run: devspace run deploy -n platform
-        working-directory: service
-
-      - name: Deploy agents-orchestrator from source
-        run: devspace run deploy -n platform
-        working-directory: agents-orchestrator
+        run: devspace run deploy
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
-        env:
-          AGN_INIT_IMAGE: ${{ env.AGN_INIT_IMAGE }}
-          CODEX_INIT_IMAGE: ${{ env.CODEX_INIT_IMAGE }}
-          CLAUDE_INIT_IMAGE: ${{ env.CLAUDE_INIT_IMAGE }}
-          AGN_EXPOSE_INIT_IMAGE: ${{ env.AGN_EXPOSE_INIT_IMAGE }}
-          AGYN_AGENT_INIT_IMAGE: ${{ env.AGYN_AGENT_INIT_IMAGE }}
         with:
           service: runners
+
+      - name: Restore ArgoCD sync
+        if: always()
+        run: devspace run restore-argocd

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Deploy runners from source
-        run: devspace run deploy
+        run: devspace dev
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
@@ -36,4 +36,4 @@ jobs:
 
       - name: Restore ArgoCD sync
         if: always()
-        run: devspace run restore-argocd
+        run: devspace run-pipeline restore-argocd

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -160,6 +160,10 @@ pipelines:
     run: |-
       restore_argocd_sync
 
+  wait-runners:
+    run: |-
+      wait_for_runners
+
 dev:
   runners:
     namespace: ${RUNNERS_NAMESPACE}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -60,10 +60,15 @@ functions:
                 - -c
                 - |
                   set -eux
-                  elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 300 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                  start=$(date +%s)
+                  while [ ! -f /opt/app/data/go.mod ] \
+                    || [ ! -f /opt/app/data/go.sum ] \
+                    || [ ! -f /opt/app/data/buf.gen.yaml ] \
+                    || [ ! -f /opt/app/data/buf.yaml ] \
+                    || [ ! -f /opt/app/data/cmd/runners/main.go ]; do
+                    sleep 1
+                    elapsed=$(( $(date +%s) - start ))
+                    [ "$elapsed" -ge 300 ] && { echo "ERROR: sync timeout waiting for source files" >&2; exit 1; }
                   done
                   echo "Files synced, starting buf generate..."
                   ls -la /opt/app/data/
@@ -131,12 +136,6 @@ functions:
     done
     echo "Runners is running from source."
 
-commands:
-  deploy: |-
-    devspace run-pipeline deploy -n ${DEVSPACE_NAMESPACE} $@
-  restore-argocd: |-
-    devspace run-pipeline restore-argocd -n ${DEVSPACE_NAMESPACE} $@
-
 pipelines:
   dev:
     flags:
@@ -152,19 +151,10 @@ pipelines:
         start_dev --disable-pod-replace runners
       else
         start_dev --disable-pod-replace runners
-        sleep 10
+        wait_for_runners
         echo "Dev environment ready. Stopping dev session."
         stop_dev runners
       fi
-
-  deploy:
-    run: |-
-      disable_argocd_sync
-      wait_for_runners_deployment
-      patch_deployment
-      start_dev --disable-pod-replace runners-deploy
-      wait_for_runners
-      echo "Deploy complete. Runners is running from source."
 
   restore-argocd:
     run: |-
@@ -199,30 +189,3 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-
-  runners-deploy:
-    namespace: ${RUNNERS_NAMESPACE}
-    labelSelector:
-      app.kubernetes.io/name: runners
-      app.kubernetes.io/instance: runners
-    containers:
-      runners:
-        container: runners
-        sync:
-          - path: ./:/opt/app/data
-            noWatch: true
-            excludePaths:
-              - .git/
-              - .devspace/
-              - /.gen/
-              - /tmp/
-            uploadExcludePaths:
-              - .git/
-              - .devspace/
-              - /.gen/
-              - /tmp/
-            downloadExcludePaths:
-              - .git/
-              - .devspace/
-              - /.gen/
-              - /tmp/


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy runners from source with DevSpace, then run `agynio/e2e/.github/actions/run-tests@main`.
- Removes service workflow cluster/test environment overrides (`AGYN_*`, `TF_VAR_*`) and the pinned agents-orchestrator checkout/deploy.
- Adds read-only workflow permissions to CI/E2E.
- Verified PR workflows do not build or publish images/charts and shared agynio actions use `@main` refs.

Closes #54

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/notifications/v1` — passed.
- `go test ./...` — 71 passed, 0 failed, 0 skipped.
- `go build ./...` — passed.