### PR TITLE
fix(workloads): allow agent self GetWorkload

### DIFF
--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -451,8 +451,10 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
-		return nil, err
+	if callerID != workload.AgentID {
+		if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
+			return nil, err
+		}
 	}
 	workloads, err := s.buildWorkloadProtos(ctx, []workloadRecord{workload})
 	if err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -827,6 +827,65 @@ func TestListWorkloadsByThreadInvalidPageToken(t *testing.T) {
 	}
 }
 
+func TestGetWorkloadAllowsAgentSelfAccessWithoutAuthz(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
+
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			t.Fatal("authorization Check should not be called for agent self-access")
+			return nil, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, agentID.String()))
+	resp, err := srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if err != nil {
+		t.Fatalf("GetWorkload failed: %v", err)
+	}
+	if resp.GetWorkload().GetMeta().GetId() != workloadID.String() {
+		t.Fatalf("expected workload id %q, got %q", workloadID.String(), resp.GetWorkload().GetMeta().GetId())
+	}
+	if resp.GetWorkload().GetAgentName() != agentName {
+		t.Fatalf("expected agent name %q, got %q", agentName, resp.GetWorkload().GetAgentName())
+	}
+	if resp.GetWorkload().GetRunnerName() != runnerName {
+		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkload().GetRunnerName())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
@@ -868,6 +927,12 @@ func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
 	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
 		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
 	}
+	if gotCheckReq.GetTupleKey().GetUser() != identityObject(callerID) {
+		t.Fatalf("expected caller identity object %q, got %q", identityObject(callerID), gotCheckReq.GetTupleKey().GetUser())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReq.GetTupleKey().GetObject())
+	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
@@ -906,7 +971,9 @@ func TestGetWorkloadReturnsAgentState(t *testing.T) {
 		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
 	}}
 
+	var gotCheckReq *authorizationv1.CheckRequest
 	authorizationClient := fakeAuthorizationClient{check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		gotCheckReq = req
 		return &authorizationv1.CheckResponse{Allowed: true}, nil
 	}}
 
@@ -924,6 +991,18 @@ func TestGetWorkloadReturnsAgentState(t *testing.T) {
 	}
 	if resp.GetWorkload().GetRunnerName() != runnerName {
 		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkload().GetRunnerName())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetUser() != identityObject(callerID) {
+		t.Fatalf("expected caller identity object %q, got %q", identityObject(callerID), gotCheckReq.GetTupleKey().GetUser())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReq.GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- Allow `GetWorkload` when the caller identity matches the workload `agent_id`.
- Keep the existing `can_view_workloads` authorization path for all non-self callers.
- Add regression coverage for self-access, denied unrelated callers, and allowed org-level access.

Fixes #56

## Test & Lint Summary
- `go test ./...` passed.
- `go test -json ./...` reported 72 passed, 0 failed, 0 skipped.
- `go vet ./...` passed with no errors.
- `go build ./...` passed.