### PR TITLE
fix(workloads): use view relation for thread list

### DIFF
--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -94,3 +94,15 @@ func (s *Server) memberAllowed(ctx context.Context, identityID uuid.UUID, organi
 	cache[organizationID] = allowed
 	return allowed, nil
 }
+
+func (s *Server) orgRelationAllowedCached(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string, cache map[uuid.UUID]bool) (bool, error) {
+	if allowed, ok := cache[organizationID]; ok {
+		return allowed, nil
+	}
+	allowed, err := s.orgRelationAllowed(ctx, identityID, organizationID, relation)
+	if err != nil {
+		return false, err
+	}
+	cache[organizationID] = allowed
+	return allowed, nil
+}

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -491,10 +491,10 @@ func (s *Server) ListWorkloadsByThread(ctx context.Context, req *runnersv1.ListW
 		return nil, status.Errorf(codes.Internal, "list workloads: %v", err)
 	}
 	if callerID != nil {
-		memberCache := map[uuid.UUID]bool{}
+		viewWorkloadsCache := map[uuid.UUID]bool{}
 		filtered := make([]workloadRecord, 0, len(workloads))
 		for _, workload := range workloads {
-			allowed, err := s.memberAllowed(ctx, *callerID, workload.OrganizationID, memberCache)
+			allowed, err := s.orgRelationAllowedCached(ctx, *callerID, workload.OrganizationID, organizationViewWorkloads, viewWorkloadsCache)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -716,6 +716,66 @@ func TestListWorkloadsByThreadInternalNoIdentity(t *testing.T) {
 	}
 }
 
+func TestListWorkloadsByThreadUsesViewWorkloadsRelation(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+	limit := normalizePageSize(0)
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE thread_id = $1 ORDER BY created_at DESC, id DESC LIMIT $2", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(threadID, int(limit)+1).
+		WillReturnRows(rows)
+
+	var gotCheckReqs []*authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{
+		check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			gotCheckReqs = append(gotCheckReqs, req)
+			allowed := req.GetTupleKey().GetRelation() == organizationViewWorkloads
+			return &authorizationv1.CheckResponse{Allowed: allowed}, nil
+		},
+	}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.ListWorkloadsByThread(ctx, &runnersv1.ListWorkloadsByThreadRequest{ThreadId: threadID.String()})
+	if err != nil {
+		t.Fatalf("ListWorkloadsByThread failed: %v", err)
+	}
+	if len(resp.GetWorkloads()) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.GetWorkloads()))
+	}
+	if resp.GetWorkloads()[0].GetOrganizationId() != organizationID.String() {
+		t.Fatalf("expected organization id %q, got %q", organizationID.String(), resp.GetWorkloads()[0].GetOrganizationId())
+	}
+	if len(gotCheckReqs) != 1 {
+		t.Fatalf("expected 1 authorization check, got %d", len(gotCheckReqs))
+	}
+	if gotCheckReqs[0].GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReqs[0].GetTupleKey().GetRelation())
+	}
+	if gotCheckReqs[0].GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReqs[0].GetTupleKey().GetObject())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestListWorkloadsByThreadPagination(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix `ListWorkloadsByThread` to filter caller-visible workloads through `can_view_workloads` instead of direct org `member`.
- Add cached org-relation helper for per-page filtering.
- Add regression coverage for callers that can view workloads without direct member access.

Closes #58

## Test & lint summary

- `go test ./...`: passed 72 / failed 0 / skipped 0
- `go vet ./...`: passed with no errors