### PR TITLE
fix(e2e): wait for fresh runners endpoint

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,14 +29,30 @@ jobs:
       - name: Deploy runners from source
         run: |
           set -euo pipefail
+          RUNNERS_SOURCE_DEPLOY_ID="${GITHUB_RUN_ID:-$(date +%s)}"
+          export RUNNERS_SOURCE_DEPLOY_ID
           RUNNER_TRACKING_ID="" devspace dev --watch > /tmp/runners-devspace.log 2>&1 &
           echo "$!" > /tmp/runners-devspace.pid
           devspace run-pipeline wait-runners
 
       - name: Run E2E tests
+        id: e2e
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: runners
+
+      - name: Dump runners diagnostics
+        if: always() && steps.e2e.outcome != 'success'
+        run: |
+          set +e
+          devspace run-pipeline diagnostics-runners
+          echo "::group::runners devspace log"
+          if [ -f /tmp/runners-devspace.log ]; then
+            tail -n 500 /tmp/runners-devspace.log
+          else
+            echo "/tmp/runners-devspace.log not found"
+          fi
+          echo "::endgroup::"
 
       - name: Restore ArgoCD sync
         if: always()

--- a/cmd/runners/main.go
+++ b/cmd/runners/main.go
@@ -113,7 +113,11 @@ func run() error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		log.Print("runners: ready")
+		readyMessage := "runners: ready"
+		if sourceDeployID := os.Getenv("RUNNERS_SOURCE_DEPLOY_ID"); sourceDeployID != "" {
+			readyMessage = fmt.Sprintf("%s source_deploy_id=%s", readyMessage, sourceDeployID)
+		}
+		log.Print(readyMessage)
 		if err := grpcServer.Serve(listener); err != nil {
 			errCh <- err
 		}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -25,6 +25,24 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'runners' not found in argocd namespace."
     fi
+  dump_runners_diagnostics: &dump_runners_diagnostics |-
+    LABEL_SELECTOR="app.kubernetes.io/name=runners,app.kubernetes.io/instance=runners"
+    echo "::group::runners diagnostics"
+    echo "Runners pods:"
+    kubectl get pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide || true
+    echo "Runners service:"
+    kubectl get service runners -n ${RUNNERS_NAMESPACE} -o wide || true
+    echo "Runners endpoints:"
+    kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o wide || true
+    echo "Runners endpoint slices:"
+    kubectl get endpointslices -n ${RUNNERS_NAMESPACE} -l kubernetes.io/service-name=runners -o wide || true
+    echo "Runners logs (tail 300):"
+    kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=300 --prefix=true || true
+    echo "Runners previous logs (tail 300):"
+    kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=300 --prefix=true --previous || true
+    echo "Runners pod describe:"
+    kubectl describe pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" || true
+    echo "::endgroup::"
   wait_for_runners_deployment: |-
     echo "Waiting for runners deployment to exist..."
     ELAPSED=0
@@ -40,7 +58,10 @@ functions:
     echo "Runners deployment found."
   patch_deployment: |-
     echo "Patching runners deployment for DevSpace..."
-    kubectl patch deployment runners -n ${RUNNERS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    RUNNERS_SOURCE_DEPLOY_ID="${RUNNERS_SOURCE_DEPLOY_ID:-$(date +%s)}"
+    export RUNNERS_SOURCE_DEPLOY_ID
+    SOURCE_DEPLOY_ID="${RUNNERS_SOURCE_DEPLOY_ID}"
+    PATCH_CONTENT="$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -55,16 +76,26 @@ functions:
             - name: runners
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
               workingDir: /opt/app/data
+              env:
+                - name: RUNNERS_SOURCE_DEPLOY_ID
+                  value: "__SOURCE_DEPLOY_ID__"
+                - name: GOMODCACHE
+                  value: /opt/app/cache/go/pkg/mod
+                - name: GOCACHE
+                  value: /opt/app/cache/go-build
               command:
                 - sh
                 - -c
                 - |
                   set -eux
+                  mkdir -p /opt/app/cache/go/pkg/mod /opt/app/cache/go-build
                   start=$(date +%s)
                   while [ ! -f /opt/app/data/go.mod ] \
                     || [ ! -f /opt/app/data/go.sum ] \
                     || [ ! -f /opt/app/data/buf.gen.yaml ] \
                     || [ ! -f /opt/app/data/buf.yaml ] \
+                    || [ ! -f /opt/app/data/migrations/embed.go ] \
+                    || [ ! -f /opt/app/data/migrations/0001_init.sql ] \
                     || [ ! -f /opt/app/data/cmd/runners/main.go ]; do
                     sleep 1
                     elapsed=$(( $(date +%s) - start ))
@@ -108,6 +139,9 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+    PATCH_CONTENT="${PATCH_CONTENT/__SOURCE_DEPLOY_ID__/${SOURCE_DEPLOY_ID}}"
+    kubectl patch deployment runners -n ${RUNNERS_NAMESPACE} --type strategic --patch "${PATCH_CONTENT}"
+    kubectl rollout restart deployment/runners -n ${RUNNERS_NAMESPACE}
   wait_for_runners: |-
     echo "Waiting for runners deployment to roll out..."
     kubectl rollout status deployment/runners \
@@ -116,20 +150,31 @@ functions:
     echo "Waiting for runners source sync and process start..."
     ELAPSED=0
     LABEL_SELECTOR="app.kubernetes.io/name=runners,app.kubernetes.io/instance=runners"
+    SOURCE_DEPLOY_ID="${RUNNERS_SOURCE_DEPLOY_ID:-}"
+    READY_PATTERN="runners: ready"
+    if [ -n "${SOURCE_DEPLOY_ID}" ]; then
+      READY_PATTERN="runners: ready source_deploy_id=${SOURCE_DEPLOY_ID}"
+    fi
     until kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
-      grep -q "runners: ready"; do
+      grep -q "${READY_PATTERN}"; do
       sleep 5
       ELAPSED=$((ELAPSED + 5))
       if [ "$ELAPSED" -ge 600 ]; then
         echo "ERROR: runners ready log not found within 600s" >&2
-        echo "Diagnostic pod list:" >&2
-        kubectl get pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
-        echo "Diagnostic logs (tail 200):" >&2
-        kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 >&2 || true
-        echo "Diagnostic previous logs (tail 200):" >&2
-        kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 --previous >&2 || true
-        echo "Diagnostic pod describe:" >&2
-        kubectl describe pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" >&2 || true
+        dump_runners_diagnostics >&2
+        exit 1
+      fi
+      echo "  still waiting... (${ELAPSED}s)"
+    done
+
+    echo "Waiting for runners service endpoints..."
+    ELAPSED=0
+    until kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null | grep -q .; do
+      sleep 5
+      ELAPSED=$((ELAPSED + 5))
+      if [ "$ELAPSED" -ge 300 ]; then
+        echo "ERROR: runners service has no ready endpoints within 300s" >&2
+        dump_runners_diagnostics >&2
         exit 1
       fi
       echo "  still waiting... (${ELAPSED}s)"
@@ -163,6 +208,10 @@ pipelines:
   wait-runners:
     run: |-
       wait_for_runners
+
+  diagnostics-runners:
+    run: |-
+      dump_runners_diagnostics
 
 dev:
   runners:


### PR DESCRIPTION
## Summary

- Fix runners source-deploy readiness so E2E waits for a fresh source pod ready marker instead of stale logs.
- Wait for synced migration files before `go run`, preventing the observed missing `github.com/agynio/runners/migrations` package crash.
- Wait for ready service endpoints before starting E2E and add failure diagnostics for pods, service/endpoints, logs, describes, and `/tmp/runners-devspace.log`.

Follow-up to #59 after it was merged.

## Test & lint summary

- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/notifications/v1`: completed successfully
- `go test ./...`: passed 1 / failed 0 / skipped 0
- `go vet ./...`: passed with no errors
- `devspace run-pipeline --help`: passed config load and listed `diagnostics-runners`