### PR TITLE
fix(workloads): allow agent self GetWorkload

### DIFF
--- a/internal/server/runners_test.go
+++ b/internal/server/runners_test.go
@@ -107,6 +107,7 @@ func (f fakeZitiManagementClient) DeleteDeviceIdentity(ctx context.Context, req 
 
 type fakeIdentityClient struct {
 	registerIdentity func(ctx context.Context, req *identityv1.RegisterIdentityRequest) (*identityv1.RegisterIdentityResponse, error)
+	getIdentityType  func(ctx context.Context, req *identityv1.GetIdentityTypeRequest) (*identityv1.GetIdentityTypeResponse, error)
 }
 
 func (f fakeIdentityClient) RegisterIdentity(ctx context.Context, req *identityv1.RegisterIdentityRequest, opts ...grpc.CallOption) (*identityv1.RegisterIdentityResponse, error) {
@@ -117,7 +118,10 @@ func (f fakeIdentityClient) RegisterIdentity(ctx context.Context, req *identityv
 }
 
 func (f fakeIdentityClient) GetIdentityType(ctx context.Context, req *identityv1.GetIdentityTypeRequest, opts ...grpc.CallOption) (*identityv1.GetIdentityTypeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+	if f.getIdentityType == nil {
+		return nil, status.Error(codes.Unimplemented, "not implemented")
+	}
+	return f.getIdentityType(ctx, req)
 }
 
 func (f fakeIdentityClient) BatchGetIdentityTypes(ctx context.Context, req *identityv1.BatchGetIdentityTypesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetIdentityTypesResponse, error) {

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -451,8 +451,10 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
-		return nil, err
+	if callerID != workload.AgentID {
+		if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
+			return nil, err
+		}
 	}
 	workloads, err := s.buildWorkloadProtos(ctx, []workloadRecord{workload})
 	if err != nil {

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	identityv1 "github.com/agynio/runners/.gen/go/agynio/api/identity/v1"
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
@@ -451,7 +452,15 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if callerID != workload.AgentID {
+	allowAgentSelfAccess := false
+	if callerID == workload.AgentID {
+		identityTypeResp, err := s.identityClient.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: callerID.String()})
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "identity type: %v", err)
+		}
+		allowAgentSelfAccess = identityTypeResp.GetIdentityType() == identityv1.IdentityType_IDENTITY_TYPE_AGENT
+	}
+	if !allowAgentSelfAccess {
 		if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
 			return nil, err
 		}

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -934,6 +934,112 @@ func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
 	}
 }
 
+func TestGetWorkloadAllowsOwningAgent(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
+
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	checkCalls := 0
+	authorizationClient := fakeAuthorizationClient{check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		checkCalls++
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, agentID.String()))
+	resp, err := srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if err != nil {
+		t.Fatalf("GetWorkload failed: %v", err)
+	}
+	if resp.GetWorkload().GetMeta().GetId() != workloadID.String() {
+		t.Fatalf("expected workload id %q, got %q", workloadID.String(), resp.GetWorkload().GetMeta().GetId())
+	}
+	if resp.GetWorkload().GetAgentId() != agentID.String() {
+		t.Fatalf("expected agent id %q, got %q", agentID.String(), resp.GetWorkload().GetAgentId())
+	}
+	if checkCalls != 0 {
+		t.Fatalf("expected no authorization checks, got %d", checkCalls)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetWorkloadDeniesNonOwningAgent(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
+
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		gotCheckReq = req
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReq.GetTupleKey().GetObject())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestGetWorkloadReturnsAgentState(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -12,6 +12,7 @@ import (
 
 	agentsv1 "github.com/agynio/runners/.gen/go/agynio/api/agents/v1"
 	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/runners/.gen/go/agynio/api/identity/v1"
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
@@ -970,8 +971,14 @@ func TestGetWorkloadAllowsOwningAgent(t *testing.T) {
 		checkCalls++
 		return &authorizationv1.CheckResponse{Allowed: false}, nil
 	}}
+	identityClient := fakeIdentityClient{getIdentityType: func(ctx context.Context, req *identityv1.GetIdentityTypeRequest) (*identityv1.GetIdentityTypeResponse, error) {
+		if req.GetIdentityId() != agentID.String() {
+			t.Fatalf("expected identity id %q, got %q", agentID.String(), req.GetIdentityId())
+		}
+		return &identityv1.GetIdentityTypeResponse{IdentityType: identityv1.IdentityType_IDENTITY_TYPE_AGENT}, nil
+	}}
 
-	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	srv := New(Options{Pool: mockPool, IdentityClient: identityClient, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, agentID.String()))
 	resp, err := srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
 	if err != nil {
@@ -985,6 +992,65 @@ func TestGetWorkloadAllowsOwningAgent(t *testing.T) {
 	}
 	if checkCalls != 0 {
 		t.Fatalf("expected no authorization checks, got %d", checkCalls)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetWorkloadDoesNotAllowNonAgentSelfAccess(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+
+	rows := pgxmock.NewRows(workloadRowColumns).
+		AddRow(workloadID, runnerID, threadID, agentID, organizationID, workloadStatusRunning, workloadAgentStateProcessing, nil, nil, containersJSON, "ziti-id", int32(0), int64(0), nil, now, nil, nil, now, now)
+
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(rows)
+
+	identityTypeCalls := 0
+	identityClient := fakeIdentityClient{getIdentityType: func(ctx context.Context, req *identityv1.GetIdentityTypeRequest) (*identityv1.GetIdentityTypeResponse, error) {
+		identityTypeCalls++
+		if req.GetIdentityId() != agentID.String() {
+			t.Fatalf("expected identity id %q, got %q", agentID.String(), req.GetIdentityId())
+		}
+		return &identityv1.GetIdentityTypeResponse{IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER}, nil
+	}}
+
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		gotCheckReq = req
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, IdentityClient: identityClient, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, agentID.String()))
+	_, err = srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if identityTypeCalls != 1 {
+		t.Fatalf("expected 1 identity type lookup, got %d", identityTypeCalls)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
+		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != organizationObject(organizationID) {
+		t.Fatalf("expected organization object %q, got %q", organizationObject(organizationID), gotCheckReq.GetTupleKey().GetObject())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary

- Allow the agent identity that owns a workload to call `GetWorkload` for that workload without org-level `can_view_workloads`.
- Keep the existing `can_view_workloads` authorization path for non-owning callers.
- Add regression tests for owning-agent allow and non-owning-agent deny behavior.

Closes #62

## Test & lint summary

- `go test ./...`: passed 74 / failed 0 / skipped 0
- `go vet ./...`: passed with no errors