### PR TITLE
fix(authz): authorize workload access via tuples

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,15 +33,26 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
 
+          variables_old = "\n".join([
+              'variable "authorization_chart_version" {',
+              '  type        = string',
+              '  description = "Version of the authorization Helm chart published to GHCR"',
+              '  default     = "0.5.3"',
+              '}',
+          ])
+          variables_new = "\n".join([
+              'variable "authorization_chart_version" {',
+              '  type        = string',
+              '  description = "Version of the authorization Helm chart published to GHCR"',
+              '  default     = "0.5.4"',
+              '}',
+          ])
           replacements = {
               Path("main.tf"): (
                   "github.com/agynio/authorization//terraform?ref=v0.5.3",
                   "github.com/agynio/authorization//terraform?ref=v0.5.4",
               ),
-              Path("variables.tf"): (
-                  'default = "0.5.3"',
-                  'default = "0.5.4"',
-              ),
+              Path("variables.tf"): (variables_old, variables_new),
           }
           for path, (old, new) in replacements.items():
               content = path.read_text()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,22 +23,38 @@ jobs:
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
 
+      - name: Setup DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
+
       - name: Upgrade authorization model
         working-directory: bootstrap/stacks/platform
         run: |
           set -euo pipefail
-          terraform init \
-            -upgrade \
-            -target=module.openfga_authorization \
-            -from-module=github.com/agynio/authorization//terraform?ref=v0.5.4
+          python3 - <<'PY'
+          from pathlib import Path
+
+          replacements = {
+              Path("main.tf"): (
+                  "github.com/agynio/authorization//terraform?ref=v0.5.3",
+                  "github.com/agynio/authorization//terraform?ref=v0.5.4",
+              ),
+              Path("variables.tf"): (
+                  'default = "0.5.3"',
+                  'default = "0.5.4"',
+              ),
+          }
+          for path, (old, new) in replacements.items():
+              content = path.read_text()
+              if old not in content:
+                  raise SystemExit(f"expected authorization v0.5.3 reference in {path}")
+              path.write_text(content.replace(old, new, 1))
+          PY
+          terraform init -upgrade
           terraform apply \
             -auto-approve \
             -target=module.openfga_authorization \
             -target=openfga_relationship_tuple.cluster_admin \
             -target=argocd_application.authorization
-
-      - name: Setup DevSpace
-        uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Install gRPC health probe
         run: |
@@ -70,4 +86,8 @@ jobs:
             kill "$(cat /tmp/runners-devspace.pid)"
             wait "$(cat /tmp/runners-devspace.pid)" || true
           fi
-          devspace run-pipeline restore-argocd
+          if command -v devspace >/dev/null 2>&1; then
+            devspace run-pipeline restore-argocd
+          else
+            echo "DevSpace is not installed; skipping ArgoCD sync restore."
+          fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,20 @@ jobs:
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
 
+      - name: Upgrade authorization model
+        working-directory: bootstrap/stacks/platform
+        run: |
+          set -euo pipefail
+          terraform init \
+            -upgrade \
+            -target=module.openfga_authorization \
+            -from-module=github.com/agynio/authorization//terraform?ref=v0.5.4
+          terraform apply \
+            -auto-approve \
+            -target=module.openfga_authorization \
+            -target=openfga_relationship_tuple.cluster_admin \
+            -target=argocd_application.authorization
+
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
+      - name: Install gRPC health probe
+        run: |
+          set -euo pipefail
+          version="v0.4.38"
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o /tmp/grpc_health_probe \
+            "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${version}/grpc_health_probe-linux-amd64"
+          sudo install -c -m 0755 /tmp/grpc_health_probe /usr/local/bin/grpc_health_probe
+          grpc_health_probe -version
+
       - name: Deploy runners from source
         run: |
           set -euo pipefail

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,6 @@ jobs:
           set +e
           if [ -f /tmp/runners-devspace.pid ]; then
             kill "$(cat /tmp/runners-devspace.pid)"
-            wait "$(cat /tmp/runners-devspace.pid)"
+            wait "$(cat /tmp/runners-devspace.pid)" || true
           fi
           devspace run-pipeline restore-argocd

--- a/cmd/runners/main.go
+++ b/cmd/runners/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func main() {
@@ -103,6 +105,9 @@ func run() error {
 		ZitiDialer:           zitiManager,
 	})
 	runnersv1.RegisterRunnersServiceServer(grpcServer, srv)
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	go srv.RunWorkloadActivitySweep(ctx, cfg.WorkloadActivitySweepInterval, cfg.WorkloadKeepaliveGrace)
 
 	listener, err := net.Listen("tcp", cfg.GRPCAddr)

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -215,6 +215,8 @@ functions:
       done
       kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
       if [ "${READY}" = "true" ]; then
+        echo "Runners TCP endpoint accepted connections:"
+        cat /tmp/runners-nc.log || true
         break
       fi
       ELAPSED=$((ELAPSED + 10))
@@ -255,6 +257,8 @@ functions:
       done
       kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
       if [ "${READY}" = "true" ]; then
+        echo "Runners gRPC health probe succeeded:"
+        cat /tmp/runners-grpc-health.log || true
         break
       fi
       ELAPSED=$((ELAPSED + 10))

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -193,7 +193,6 @@ functions:
         sleep 1
       done
       kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
-      wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
       if [ "${READY}" = "true" ]; then
         break
       fi

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -191,6 +191,10 @@ functions:
       echo "  still waiting... (${ELAPSED}s)"
     done
 
+    echo "Runners service diagnostics before connection checks:"
+    kubectl get service runners -n ${RUNNERS_NAMESPACE} -o wide
+    kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o wide
+
     echo "Waiting for runners TCP endpoint on port 50051..."
     ELAPSED=0
     PORT_FORWARD_LOG="/tmp/runners-port-forward.log"
@@ -200,7 +204,7 @@ functions:
       PORT_FORWARD_PID=$!
       READY="false"
       for _ in 1 2 3 4 5 6 7 8 9 10; do
-        if nc -z 127.0.0.1 15051 >/dev/null 2>&1; then
+        if nc -zv -w 2 127.0.0.1 15051 >/tmp/runners-nc.log 2>&1; then
           READY="true"
           break
         fi
@@ -216,6 +220,8 @@ functions:
       ELAPSED=$((ELAPSED + 10))
       if [ "$ELAPSED" -ge 300 ]; then
         echo "ERROR: runners TCP endpoint was not accepting connections within 300s" >&2
+        echo "Diagnostic netcat log:" >&2
+        cat /tmp/runners-nc.log >&2 || true
         echo "Diagnostic port-forward log:" >&2
         cat "${PORT_FORWARD_LOG}" >&2 || true
         echo "Diagnostic endpoints:" >&2
@@ -238,7 +244,7 @@ functions:
       PORT_FORWARD_PID=$!
       READY="false"
       for _ in 1 2 3 4 5 6 7 8 9 10; do
-        if grpc_health_probe -addr=127.0.0.1:15051 -connect-timeout=2s -rpc-timeout=2s >/dev/null 2>&1; then
+        if grpc_health_probe -addr=127.0.0.1:15051 -connect-timeout=2s -rpc-timeout=2s >/tmp/runners-grpc-health.log 2>&1; then
           READY="true"
           break
         fi
@@ -254,6 +260,8 @@ functions:
       ELAPSED=$((ELAPSED + 10))
       if [ "$ELAPSED" -ge 300 ]; then
         echo "ERROR: runners gRPC health endpoint was not serving within 300s" >&2
+        echo "Diagnostic grpc_health_probe log:" >&2
+        cat /tmp/runners-grpc-health.log >&2 || true
         echo "Diagnostic port-forward log:" >&2
         cat "${PORT_FORWARD_LOG}" >&2 || true
         echo "Diagnostic endpoints:" >&2

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -109,14 +109,53 @@ functions:
     EOF
     )"
   wait_for_runners: |-
+    echo "Waiting for runners deployment source patch..."
+    ELAPSED=0
+    until [ "$(kubectl get deployment runners -n ${RUNNERS_NAMESPACE} -o jsonpath='{.spec.template.spec.containers[?(@.name=="runners")].image}' 2>/dev/null || true)" = "${DEV_IMAGE}" ]; do
+      sleep 5
+      ELAPSED=$((ELAPSED + 5))
+      if [ "$ELAPSED" -ge 300 ]; then
+        echo "ERROR: runners deployment was not patched to ${DEV_IMAGE} within 300s" >&2
+        echo "Diagnostic deployment:" >&2
+        kubectl get deployment runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        exit 1
+      fi
+      echo "  still waiting for source patch... (${ELAPSED}s)"
+    done
+
     echo "Waiting for runners deployment to roll out..."
     kubectl rollout status deployment/runners \
-      -n ${RUNNERS_NAMESPACE} --timeout=120s
+      -n ${RUNNERS_NAMESPACE} --timeout=600s
+
+    LABEL_SELECTOR="app.kubernetes.io/name=runners,app.kubernetes.io/instance=runners"
+
+    echo "Waiting for runners pod readiness..."
+    kubectl wait pod -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" \
+      --for=condition=Ready --timeout=600s
+
+    echo "Waiting for runners service endpoints..."
+    ELAPSED=0
+    until [ -n "$(kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)" ]; do
+      sleep 5
+      ELAPSED=$((ELAPSED + 5))
+      if [ "$ELAPSED" -ge 300 ]; then
+        echo "ERROR: runners service endpoints not ready within 300s" >&2
+        echo "Diagnostic service:" >&2
+        kubectl get service runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        echo "Diagnostic endpoints:" >&2
+        kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        echo "Diagnostic pods:" >&2
+        kubectl get pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+        exit 1
+      fi
+      echo "  still waiting for endpoints... (${ELAPSED}s)"
+    done
 
     echo "Waiting for runners source sync and process start..."
     ELAPSED=0
-    LABEL_SELECTOR="app.kubernetes.io/name=runners,app.kubernetes.io/instance=runners"
     until kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
+      grep -q "buf generate complete, starting go run" && \
+      kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
       grep -q "runners: ready"; do
       sleep 5
       ELAPSED=$((ELAPSED + 5))
@@ -133,6 +172,45 @@ functions:
         exit 1
       fi
       echo "  still waiting... (${ELAPSED}s)"
+    done
+
+    echo "Waiting for runners gRPC health endpoint on port 50051..."
+    ELAPSED=0
+    PORT_FORWARD_LOG="/tmp/runners-port-forward.log"
+    while true; do
+      rm -f "${PORT_FORWARD_LOG}"
+      kubectl port-forward -n ${RUNNERS_NAMESPACE} svc/runners 15051:50051 >"${PORT_FORWARD_LOG}" 2>&1 &
+      PORT_FORWARD_PID=$!
+      READY="false"
+      for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if grpc_health_probe -addr=127.0.0.1:15051 -connect-timeout=2s -rpc-timeout=2s >/dev/null 2>&1; then
+          READY="true"
+          break
+        fi
+        if ! kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+          break
+        fi
+        sleep 1
+      done
+      kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+      wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+      if [ "${READY}" = "true" ]; then
+        break
+      fi
+      ELAPSED=$((ELAPSED + 10))
+      if [ "$ELAPSED" -ge 300 ]; then
+        echo "ERROR: runners gRPC health endpoint was not serving within 300s" >&2
+        echo "Diagnostic port-forward log:" >&2
+        cat "${PORT_FORWARD_LOG}" >&2 || true
+        echo "Diagnostic endpoints:" >&2
+        kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        echo "Diagnostic pods:" >&2
+        kubectl get pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+        echo "Diagnostic logs (tail 200):" >&2
+        kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 >&2 || true
+        exit 1
+      fi
+      echo "  still waiting for gRPC health... (${ELAPSED}s)"
     done
     echo "Runners is running from source."
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -65,7 +65,8 @@ functions:
                     || [ ! -f /opt/app/data/go.sum ] \
                     || [ ! -f /opt/app/data/buf.gen.yaml ] \
                     || [ ! -f /opt/app/data/buf.yaml ] \
-                    || [ ! -f /opt/app/data/cmd/runners/main.go ]; do
+                    || [ ! -f /opt/app/data/cmd/runners/main.go ] \
+                    || [ ! -f /opt/app/data/internal/zitimanager/manager.go ]; do
                     sleep 1
                     elapsed=$(( $(date +%s) - start ))
                     [ "$elapsed" -ge 300 ] && { echo "ERROR: sync timeout waiting for source files" >&2; exit 1; }

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -190,6 +190,44 @@ functions:
       echo "  still waiting... (${ELAPSED}s)"
     done
 
+    echo "Waiting for runners TCP endpoint on port 50051..."
+    ELAPSED=0
+    PORT_FORWARD_LOG="/tmp/runners-port-forward.log"
+    while true; do
+      rm -f "${PORT_FORWARD_LOG}"
+      kubectl port-forward -n ${RUNNERS_NAMESPACE} svc/runners 15051:50051 >"${PORT_FORWARD_LOG}" 2>&1 &
+      PORT_FORWARD_PID=$!
+      READY="false"
+      for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if nc -z 127.0.0.1 15051 >/dev/null 2>&1; then
+          READY="true"
+          break
+        fi
+        if ! kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+          break
+        fi
+        sleep 1
+      done
+      kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+      if [ "${READY}" = "true" ]; then
+        break
+      fi
+      ELAPSED=$((ELAPSED + 10))
+      if [ "$ELAPSED" -ge 300 ]; then
+        echo "ERROR: runners TCP endpoint was not accepting connections within 300s" >&2
+        echo "Diagnostic port-forward log:" >&2
+        cat "${PORT_FORWARD_LOG}" >&2 || true
+        echo "Diagnostic endpoints:" >&2
+        kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        echo "Diagnostic pods:" >&2
+        kubectl get pods -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" -o wide >&2 || true
+        echo "Diagnostic logs (tail 200):" >&2
+        kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 >&2 || true
+        exit 1
+      fi
+      echo "  still waiting for TCP port 50051... (${ELAPSED}s)"
+    done
+
     echo "Waiting for runners gRPC health endpoint on port 50051..."
     ELAPSED=0
     PORT_FORWARD_LOG="/tmp/runners-port-forward.log"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -151,6 +151,22 @@ functions:
       echo "  still waiting for endpoints... (${ELAPSED}s)"
     done
 
+    echo "Waiting for runners service endpoint port 50051..."
+    ELAPSED=0
+    until [ -n "$(kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o jsonpath='{.subsets[*].ports[?(@.port==50051)].port}' 2>/dev/null || true)" ]; do
+      sleep 5
+      ELAPSED=$((ELAPSED + 5))
+      if [ "$ELAPSED" -ge 300 ]; then
+        echo "ERROR: runners service endpoint port 50051 not ready within 300s" >&2
+        echo "Diagnostic service:" >&2
+        kubectl get service runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        echo "Diagnostic endpoints:" >&2
+        kubectl get endpoints runners -n ${RUNNERS_NAMESPACE} -o yaml >&2 || true
+        exit 1
+      fi
+      echo "  still waiting for endpoint port 50051... (${ELAPSED}s)"
+    done
+
     echo "Waiting for runners source sync and process start..."
     ELAPSED=0
     until kubectl logs -n ${RUNNERS_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,8 +26,12 @@ const (
 	organizationOwnerRelation  = "owner"
 	organizationViewWorkloads  = "can_view_workloads"
 	organizationViewVolumes    = "can_view_volumes"
+	workloadOrgRelation        = "org"
+	workloadOwnerAgentRelation = "owner_agent"
+	workloadCanViewRelation    = "can_view"
 	identityObjectPrefix       = "identity:"
 	organizationObjectPrefix   = "organization:"
+	workloadObjectPrefix       = "workload:"
 	identityMetadata           = "x-identity-id"
 )
 
@@ -131,4 +135,8 @@ func identityObject(id uuid.UUID) string {
 
 func organizationObject(id uuid.UUID) string {
 	return organizationObjectPrefix + id.String()
+}
+
+func workloadObject(id uuid.UUID) string {
+	return workloadObjectPrefix + id.String()
 }

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -170,10 +170,6 @@ func (s *Server) CreateWorkload(ctx context.Context, req *runnersv1.CreateWorklo
 		return nil, status.Errorf(codes.Internal, "marshal containers: %v", err)
 	}
 
-	if err := s.writeWorkloadAuthorization(ctx, id, organizationID, agentID); err != nil {
-		return nil, err
-	}
-
 	workload, err := s.insertWorkload(ctx, workloadInsertInput{
 		ID:                     id,
 		RunnerID:               runnerID,
@@ -187,8 +183,10 @@ func (s *Server) CreateWorkload(ctx context.Context, req *runnersv1.CreateWorklo
 		AllocatedRAMBytes:      req.GetAllocatedRamBytes(),
 	})
 	if err != nil {
-		s.cleanupWorkloadAuthorization(ctx, id, organizationID, agentID)
 		return nil, toStatusError(err)
+	}
+	if err := s.writeWorkloadAuthorization(ctx, id, organizationID, agentID); err != nil {
+		return nil, err
 	}
 
 	protoWorkload, err := toProtoWorkload(workload)
@@ -646,11 +644,6 @@ func (s *Server) writeWorkloadAuthorization(ctx context.Context, workloadID, org
 		return status.Errorf(codes.Internal, "authorization write: %v", err)
 	}
 	return nil
-}
-
-func (s *Server) cleanupWorkloadAuthorization(ctx context.Context, workloadID, organizationID, agentID uuid.UUID) {
-	tuples := workloadAuthorizationTuples(workloadID, organizationID, agentID)
-	_, _ = s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{Deletes: tuples})
 }
 
 func workloadAuthorizationTuples(workloadID, organizationID, agentID uuid.UUID) []*authorizationv1.TupleKey {

--- a/internal/server/workloads.go
+++ b/internal/server/workloads.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	authorizationv1 "github.com/agynio/runners/.gen/go/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/runners/.gen/go/agynio/api/notifications/v1"
 	runnersv1 "github.com/agynio/runners/.gen/go/agynio/api/runners/v1"
 	"github.com/google/uuid"
@@ -169,6 +170,10 @@ func (s *Server) CreateWorkload(ctx context.Context, req *runnersv1.CreateWorklo
 		return nil, status.Errorf(codes.Internal, "marshal containers: %v", err)
 	}
 
+	if err := s.writeWorkloadAuthorization(ctx, id, organizationID, agentID); err != nil {
+		return nil, err
+	}
+
 	workload, err := s.insertWorkload(ctx, workloadInsertInput{
 		ID:                     id,
 		RunnerID:               runnerID,
@@ -182,6 +187,7 @@ func (s *Server) CreateWorkload(ctx context.Context, req *runnersv1.CreateWorklo
 		AllocatedRAMBytes:      req.GetAllocatedRamBytes(),
 	})
 	if err != nil {
+		s.cleanupWorkloadAuthorization(ctx, id, organizationID, agentID)
 		return nil, toStatusError(err)
 	}
 
@@ -451,7 +457,7 @@ func (s *Server) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequ
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.requireRelation(ctx, callerID, organizationViewWorkloads, organizationObject(workload.OrganizationID)); err != nil {
+	if err := s.requireRelation(ctx, callerID, workloadCanViewRelation, workloadObject(workload.Meta.ID)); err != nil {
 		return nil, err
 	}
 	workloads, err := s.buildWorkloadProtos(ctx, []workloadRecord{workload})
@@ -632,6 +638,35 @@ func (s *Server) BatchUpdateWorkloadSampledAt(ctx context.Context, req *runnersv
 		return nil, status.Errorf(codes.Internal, "batch update workloads: %v", err)
 	}
 	return &runnersv1.BatchUpdateWorkloadSampledAtResponse{}, nil
+}
+
+func (s *Server) writeWorkloadAuthorization(ctx context.Context, workloadID, organizationID, agentID uuid.UUID) error {
+	tuples := workloadAuthorizationTuples(workloadID, organizationID, agentID)
+	if _, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{Writes: tuples}); err != nil {
+		return status.Errorf(codes.Internal, "authorization write: %v", err)
+	}
+	return nil
+}
+
+func (s *Server) cleanupWorkloadAuthorization(ctx context.Context, workloadID, organizationID, agentID uuid.UUID) {
+	tuples := workloadAuthorizationTuples(workloadID, organizationID, agentID)
+	_, _ = s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{Deletes: tuples})
+}
+
+func workloadAuthorizationTuples(workloadID, organizationID, agentID uuid.UUID) []*authorizationv1.TupleKey {
+	object := workloadObject(workloadID)
+	return []*authorizationv1.TupleKey{
+		{
+			User:     organizationObject(organizationID),
+			Relation: workloadOrgRelation,
+			Object:   object,
+		},
+		{
+			User:     identityObject(agentID),
+			Relation: workloadOwnerAgentRelation,
+			Object:   object,
+		},
+	}
 }
 
 func (s *Server) insertWorkload(ctx context.Context, input workloadInsertInput) (workloadRecord, error) {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -169,21 +169,88 @@ func TestCreateWorkloadReturnsInternalWhenAuthorizationWriteFails(t *testing.T) 
 		t.Fatalf("failed to create mock pool: %v", err)
 	}
 
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+	input := workloadInsertInput{
+		ID:             workloadID,
+		RunnerID:       runnerID,
+		ThreadID:       threadID,
+		AgentID:        agentID,
+		OrganizationID: organizationID,
+		Status:         workloadStatusRunning,
+		ContainersJSON: containersJSON,
+	}
+	expectWorkloadInsert(t, mockPool, input, defaultWorkloadRecord(workloadID, runnerID, threadID, agentID, organizationID, now))
+
 	authorizationClient := fakeAuthorizationClient{write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
 		return nil, status.Error(codes.Unavailable, "authorization unavailable")
 	}}
 
 	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
 	_, err = srv.CreateWorkload(context.Background(), &runnersv1.CreateWorkloadRequest{
-		Id:             uuid.NewString(),
-		RunnerId:       uuid.NewString(),
-		ThreadId:       uuid.NewString(),
-		AgentId:        uuid.NewString(),
-		OrganizationId: uuid.NewString(),
+		Id:             workloadID.String(),
+		RunnerId:       runnerID.String(),
+		ThreadId:       threadID.String(),
+		AgentId:        agentID.String(),
+		OrganizationId: organizationID.String(),
 		Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
 	})
 	if status.Code(err) != codes.Internal {
 		t.Fatalf("expected Internal error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestCreateWorkloadDoesNotWriteAuthorizationWhenInsertFails(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	containersJSON := []byte("[]")
+	input := workloadInsertInput{
+		ID:             workloadID,
+		RunnerID:       runnerID,
+		ThreadID:       threadID,
+		AgentID:        agentID,
+		OrganizationID: organizationID,
+		Status:         workloadStatusRunning,
+		ContainersJSON: containersJSON,
+	}
+	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO workloads (id, runner_id, thread_id, agent_id, organization_id, status, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, last_activity_at, created_at, updated_at)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW(), NOW())\n\t    RETURNING %s", workloadColumns))
+	mockPool.ExpectQuery(matcher).
+		WithArgs(input.ID, input.RunnerID, input.ThreadID, input.AgentID, input.OrganizationID, input.Status, input.ContainersJSON, input.ZitiIdentityID, input.AllocatedCPUMillicores, input.AllocatedRAMBytes).
+		WillReturnError(AlreadyExists("workload"))
+
+	authorizationClient := fakeAuthorizationClient{write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+		t.Fatal("authorization Write must not be called when workload insert fails")
+		return &authorizationv1.WriteResponse{}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	_, err = srv.CreateWorkload(context.Background(), &runnersv1.CreateWorkloadRequest{
+		Id:             workloadID.String(),
+		RunnerId:       runnerID.String(),
+		ThreadId:       threadID.String(),
+		AgentId:        agentID.String(),
+		OrganizationId: organizationID.String(),
+		Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("expected AlreadyExists error, got %v", err)
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {

--- a/internal/server/workloads_test.go
+++ b/internal/server/workloads_test.go
@@ -61,6 +61,164 @@ func (f fakeNotificationsClient) Subscribe(ctx context.Context, req *notificatio
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func expectWorkloadInsert(t *testing.T, mockPool pgxmock.PgxPoolIface, input workloadInsertInput, workload workloadRecord) {
+	matcher := regexp.QuoteMeta(fmt.Sprintf("INSERT INTO workloads (id, runner_id, thread_id, agent_id, organization_id, status, containers, ziti_identity_id, allocated_cpu_millicores, allocated_ram_bytes, last_activity_at, created_at, updated_at)\n\t    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW(), NOW())\n\t    RETURNING %s", workloadColumns))
+	mockPool.ExpectQuery(matcher).
+		WithArgs(input.ID, input.RunnerID, input.ThreadID, input.AgentID, input.OrganizationID, input.Status, input.ContainersJSON, input.ZitiIdentityID, input.AllocatedCPUMillicores, input.AllocatedRAMBytes).
+		WillReturnRows(workloadRows(t, workload))
+}
+
+func workloadRows(t *testing.T, records ...workloadRecord) *pgxmock.Rows {
+	t.Helper()
+	rows := pgxmock.NewRows(workloadRowColumns)
+	for _, record := range records {
+		containersJSON, err := json.Marshal(record.Containers)
+		if err != nil {
+			t.Fatalf("marshal containers: %v", err)
+		}
+		rows.AddRow(record.Meta.ID, record.RunnerID, record.ThreadID, record.AgentID, record.OrganizationID, record.Status, record.AgentState, record.FailureReason, record.FailureMessage, containersJSON, record.ZitiIdentityID, record.AllocatedCPUMillicores, record.AllocatedRAMBytes, record.InstanceID, record.LastActivityAt, record.LastMeteringAt, record.RemovedAt, record.Meta.CreatedAt, record.Meta.UpdatedAt)
+	}
+	return rows
+}
+
+func defaultWorkloadRecord(workloadID, runnerID, threadID, agentID, organizationID uuid.UUID, now time.Time) workloadRecord {
+	return workloadRecord{
+		Meta: entityMeta{
+			ID:        workloadID,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		RunnerID:               runnerID,
+		ThreadID:               threadID,
+		AgentID:                agentID,
+		OrganizationID:         organizationID,
+		Status:                 workloadStatusRunning,
+		AgentState:             workloadAgentStateProcessing,
+		Containers:             []containerRecord{},
+		ZitiIdentityID:         "ziti-id",
+		AllocatedCPUMillicores: 0,
+		AllocatedRAMBytes:      0,
+		LastActivityAt:         now,
+	}
+}
+
+func TestCreateWorkloadWritesAuthorizationTuples(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	now := time.Now().UTC()
+	containersJSON := []byte("[]")
+	input := workloadInsertInput{
+		ID:                     workloadID,
+		RunnerID:               runnerID,
+		ThreadID:               threadID,
+		AgentID:                agentID,
+		OrganizationID:         organizationID,
+		Status:                 workloadStatusRunning,
+		ContainersJSON:         containersJSON,
+		ZitiIdentityID:         "ziti-id",
+		AllocatedCPUMillicores: 250,
+		AllocatedRAMBytes:      512,
+	}
+	expectWorkloadInsert(t, mockPool, input, defaultWorkloadRecord(workloadID, runnerID, threadID, agentID, organizationID, now))
+
+	var gotWriteReq *authorizationv1.WriteRequest
+	authorizationClient := fakeAuthorizationClient{write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+		gotWriteReq = req
+		return &authorizationv1.WriteResponse{}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	resp, err := srv.CreateWorkload(context.Background(), &runnersv1.CreateWorkloadRequest{
+		Id:                     workloadID.String(),
+		RunnerId:               runnerID.String(),
+		ThreadId:               threadID.String(),
+		AgentId:                agentID.String(),
+		OrganizationId:         organizationID.String(),
+		Status:                 runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+		ZitiIdentityId:         "ziti-id",
+		AllocatedCpuMillicores: 250,
+		AllocatedRamBytes:      512,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkload failed: %v", err)
+	}
+	if resp.GetWorkload().GetMeta().GetId() != workloadID.String() {
+		t.Fatalf("expected workload id %s, got %s", workloadID, resp.GetWorkload().GetMeta().GetId())
+	}
+	if gotWriteReq == nil {
+		t.Fatal("expected authorization Write to be called")
+	}
+	assertWorkloadAuthorizationWrites(t, gotWriteReq, workloadID, organizationID, agentID)
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestCreateWorkloadReturnsInternalWhenAuthorizationWriteFails(t *testing.T) {
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	authorizationClient := fakeAuthorizationClient{write: func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+		return nil, status.Error(codes.Unavailable, "authorization unavailable")
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	_, err = srv.CreateWorkload(context.Background(), &runnersv1.CreateWorkloadRequest{
+		Id:             uuid.NewString(),
+		RunnerId:       uuid.NewString(),
+		ThreadId:       uuid.NewString(),
+		AgentId:        uuid.NewString(),
+		OrganizationId: uuid.NewString(),
+		Status:         runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING,
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected Internal error, got %v", err)
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func assertWorkloadAuthorizationWrites(t *testing.T, req *authorizationv1.WriteRequest, workloadID, organizationID, agentID uuid.UUID) {
+	t.Helper()
+	expected := []*authorizationv1.TupleKey{
+		{
+			User:     organizationObject(organizationID),
+			Relation: workloadOrgRelation,
+			Object:   workloadObject(workloadID),
+		},
+		{
+			User:     identityObject(agentID),
+			Relation: workloadOwnerAgentRelation,
+			Object:   workloadObject(workloadID),
+		},
+	}
+	writes := req.GetWrites()
+	if len(writes) != len(expected) {
+		t.Fatalf("expected %d authorization writes, got %d", len(expected), len(writes))
+	}
+	for idx, tuple := range expected {
+		if writes[idx].GetUser() != tuple.GetUser() || writes[idx].GetRelation() != tuple.GetRelation() || writes[idx].GetObject() != tuple.GetObject() {
+			t.Fatalf("expected write %d to be %v, got %v", idx, tuple, writes[idx])
+		}
+	}
+	if len(req.GetDeletes()) != 0 {
+		t.Fatalf("expected no authorization deletes, got %d", len(req.GetDeletes()))
+	}
+}
+
 func TestListWorkloadsFiltersOrganization(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
@@ -887,7 +1045,7 @@ func TestListWorkloadsByThreadInvalidPageToken(t *testing.T) {
 	}
 }
 
-func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
+func TestGetWorkloadRequiresCanViewWorkload(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatalf("failed to create mock pool: %v", err)
@@ -925,8 +1083,14 @@ func TestGetWorkloadRequiresViewWorkloads(t *testing.T) {
 	if gotCheckReq == nil {
 		t.Fatal("expected authorization Check to be called")
 	}
-	if gotCheckReq.GetTupleKey().GetRelation() != organizationViewWorkloads {
-		t.Fatalf("expected view workloads relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	if gotCheckReq.GetTupleKey().GetRelation() != workloadCanViewRelation {
+		t.Fatalf("expected workload can view relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != workloadObject(workloadID) {
+		t.Fatalf("expected workload object %q, got %q", workloadObject(workloadID), gotCheckReq.GetTupleKey().GetObject())
+	}
+	if gotCheckReq.GetTupleKey().GetUser() != identityObject(callerID) {
+		t.Fatalf("expected identity user %q, got %q", identityObject(callerID), gotCheckReq.GetTupleKey().GetUser())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {
@@ -984,6 +1148,138 @@ func TestGetWorkloadReturnsAgentState(t *testing.T) {
 	}
 	if resp.GetWorkload().GetRunnerName() != runnerName {
 		t.Fatalf("expected runner name %q, got %q", runnerName, resp.GetWorkload().GetRunnerName())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetWorkloadOwningAgentAllowed(t *testing.T) {
+	assertGetWorkloadAllowedByAuthorization(t, true)
+}
+
+func TestGetWorkloadOrgOwnerAllowed(t *testing.T) {
+	assertGetWorkloadAllowedByAuthorization(t, false)
+}
+
+func TestGetWorkloadNonOwningAgentDenied(t *testing.T) {
+	assertGetWorkloadDeniedByAuthorization(t, false)
+}
+
+func TestGetWorkloadOwningAgentDeniedWhenAuthorizationDenies(t *testing.T) {
+	assertGetWorkloadDeniedByAuthorization(t, true)
+}
+
+func assertGetWorkloadDeniedByAuthorization(t *testing.T, callerIsOwnerAgent bool) {
+	t.Helper()
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	if callerIsOwnerAgent {
+		callerID = agentID
+	}
+	now := time.Now().UTC()
+	workload := defaultWorkloadRecord(workloadID, runnerID, threadID, agentID, organizationID, now)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(workloadRows(t, workload))
+
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		gotCheckReq = req
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	_, err = srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != workloadCanViewRelation {
+		t.Fatalf("expected workload can view relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != workloadObject(workloadID) {
+		t.Fatalf("expected workload object %q, got %q", workloadObject(workloadID), gotCheckReq.GetTupleKey().GetObject())
+	}
+	if gotCheckReq.GetTupleKey().GetUser() != identityObject(callerID) {
+		t.Fatalf("expected identity user %q, got %q", identityObject(callerID), gotCheckReq.GetTupleKey().GetUser())
+	}
+
+	if err := mockPool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func assertGetWorkloadAllowedByAuthorization(t *testing.T, callerIsOwnerAgent bool) {
+	t.Helper()
+	mockPool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("failed to create mock pool: %v", err)
+	}
+
+	workloadID := uuid.New()
+	runnerID := uuid.New()
+	threadID := uuid.New()
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	if callerIsOwnerAgent {
+		callerID = agentID
+	}
+	now := time.Now().UTC()
+	workload := defaultWorkloadRecord(workloadID, runnerID, threadID, agentID, organizationID, now)
+	query := fmt.Sprintf("SELECT %s FROM workloads WHERE id = $1", workloadColumns)
+	mockPool.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(workloadID).WillReturnRows(workloadRows(t, workload))
+
+	runnerName := "runner-name"
+	runnerRows := pgxmock.NewRows([]string{"id", "name"}).AddRow(runnerID, runnerName)
+	mockPool.ExpectQuery(regexp.QuoteMeta("SELECT id, name FROM runners WHERE id = ANY($1)")).
+		WithArgs(pgtype.FlatArray[uuid.UUID]([]uuid.UUID{runnerID})).
+		WillReturnRows(runnerRows)
+
+	agentName := "agent-name"
+	agentsClient := fakeAgentsClient{getAgent: func(ctx context.Context, req *agentsv1.GetAgentRequest) (*agentsv1.GetAgentResponse, error) {
+		return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{Name: agentName}}, nil
+	}}
+
+	var gotCheckReq *authorizationv1.CheckRequest
+	authorizationClient := fakeAuthorizationClient{check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		gotCheckReq = req
+		return &authorizationv1.CheckResponse{Allowed: true}, nil
+	}}
+
+	srv := New(Options{Pool: mockPool, AuthorizationClient: authorizationClient, AgentsClient: agentsClient})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, callerID.String()))
+	resp, err := srv.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if err != nil {
+		t.Fatalf("GetWorkload failed: %v", err)
+	}
+	if resp.GetWorkload().GetMeta().GetId() != workloadID.String() {
+		t.Fatalf("expected workload id %s, got %s", workloadID, resp.GetWorkload().GetMeta().GetId())
+	}
+	if gotCheckReq == nil {
+		t.Fatal("expected authorization Check to be called")
+	}
+	if gotCheckReq.GetTupleKey().GetRelation() != workloadCanViewRelation {
+		t.Fatalf("expected workload can view relation, got %s", gotCheckReq.GetTupleKey().GetRelation())
+	}
+	if gotCheckReq.GetTupleKey().GetObject() != workloadObject(workloadID) {
+		t.Fatalf("expected workload object %q, got %q", workloadObject(workloadID), gotCheckReq.GetTupleKey().GetObject())
+	}
+	if gotCheckReq.GetTupleKey().GetUser() != identityObject(callerID) {
+		t.Fatalf("expected identity user %q, got %q", identityObject(callerID), gotCheckReq.GetTupleKey().GetUser())
 	}
 
 	if err := mockPool.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- Write workload authorization tuples on workload creation for organization ownership and owner agent access.
- Authorize `GetWorkload` with `workload#can_view` instead of org-level `can_view_workloads`.
- Added tests for owner-agent access, org-related authorization access, non-owner denial, authorization write failures, and no service-side agent-id equality bypass.

Closes #64

## Test & Lint Summary
- `go test -count=1 ./...` — 78 passed, 0 failed, 0 skipped.
- `go vet ./...` — passed with no errors.
- `go build ./...` — passed with no errors.